### PR TITLE
feat(api): add phase 1 bootstrap for agentcore public API and contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - lib-dev-phase_1
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Show Go version
+        run: go version
+
+      - name: Run tests
+        run: go test -v ./...

--- a/PROMPTS/01-bootstrap.md
+++ b/PROMPTS/01-bootstrap.md
@@ -1,4 +1,6 @@
-Read SPEC.md carefully.
+Read PROMPTS/IMPLEMENTATION_PROMPT.md carefully.
+Also read SPEC.md for design context.
+Use PROMPTS/IMPLEMENTATION_PROMPT.md as the primary implementation source of truth for code generation scope and API shape.
 
 Generate only the initial project bootstrap for a production-grade Go library module named nats-agent-core.
 

--- a/PROMPTS/01-bootstrap.md
+++ b/PROMPTS/01-bootstrap.md
@@ -1,0 +1,38 @@
+Read SPEC.md carefully.
+
+Generate only the initial project bootstrap for a production-grade Go library module named nats-agent-core.
+
+In this phase, create only:
+1. go.mod
+2. public package files under agentcore/
+
+Implement only the public API surface and public types:
+- Config and nested configs
+- Client struct or interface skeleton
+- BaseEnvelope
+- ConfigureCommand
+- DesiredConfigRecord
+- ConfigureNotification
+- ActionCommand
+- ResultEnvelope
+- StatusEnvelope
+- StoredDesiredConfig
+- SubmissionAck
+- HealthSnapshot
+- Logger interface
+- Metrics interface
+- typed Error with Code enum
+
+Rules:
+- Do not implement internal packages yet
+- Do not implement business logic
+- Do not generate tests yet
+- Keep exported APIs documented
+- Keep files small and focused
+- Use clear JSON tags
+- Use context.Context in all networked public method signatures
+
+After generating files:
+- summarize which files were created
+- list any assumptions
+- list which requirements are partially covered by this phase

--- a/PROMPTS/01b-api-corrections.md
+++ b/PROMPTS/01b-api-corrections.md
@@ -1,0 +1,72 @@
+Read SPEC.md, REQUIREMENTS_CHECKLIST.md, and the LLD carefully.
+
+Revise the existing Phase 1 bootstrap only. Do not implement Phase 2 or later work.
+
+Scope:
+- Update only public package files under agentcore/ and go.mod if needed
+- Do not create internal packages
+- Do not add business logic
+- Do not add tests
+- Do not implement transport/session/KV/subjects/handlers internals
+
+Goal:
+Align the current Phase 1 public API with the LLD exactly where the current generated code drifted.
+
+Required corrections:
+
+1. config.go
+- Use the LLD config model as the primary baseline
+- Keep AgentConfig and ObserveConfig only if they fit cleanly
+- Restore explicit JetStreamConfig
+- Restore TLSConfig
+- Restore RetryConfig
+- Restore ExecutionConfig
+- Use pattern-oriented SubjectConfig names
+- Keep the config surface strictly public and implementation-free
+
+2. client.go
+- Make the public API signatures match the LLD
+- New must be: New(cfg Config, opts ...Option) (*Client, error)
+- ConfigureHandler must accept ConfigureNotification, not ConfigureCommand
+- WatchDesiredConfig must return (StopFunc, error)
+- Registration methods must match the LLD:
+  - RegisterConfigureHandler(target string, handler ConfigureHandler, opts ...SubscriptionOption) error
+  - RegisterActionHandler(target, action string, handler ActionHandler, opts ...SubscriptionOption) error
+  - RegisterResultHandler(target string, handler ResultHandler, opts ...SubscriptionOption) error
+  - RegisterStatusHandler(target string, handler StatusHandler, opts ...SubscriptionOption) error
+- Do not add implementation logic; keep bootstrap stubs only
+- Health state names must align with the LLD health model
+
+3. contracts.go
+- Rewrite public models to match the LLD exactly
+- Use Version, RPCID, Target, Timestamp in the common/base model where defined by the LLD
+- ConfigureCommand, DesiredConfigRecord, ConfigureNotification, ActionCommand, ResultEnvelope, StatusEnvelope, StoredDesiredConfig, SubmissionAck, and HealthSnapshot must align with the LLD field names and semantics
+- Keep payloads as json.RawMessage
+- Do not introduce extra domain-specific fields not present in the LLD
+
+4. errors.go
+- Keep typed public errors
+- Align Code enum and Error fields with the LLD
+- It is acceptable to keep CodeNotImplemented temporarily for bootstrap stubs only
+- Prefer the LLD structure for Code, Op, Subject, Key, Retryable, Err
+
+5. observe.go
+- Logger must use: Debug/Info/Warn/Error(msg string, kv ...any)
+- Metrics should match the LLD observability interface, not a generic counter/gauge/histogram interface
+
+6. doc.go
+- Ensure package documentation describes the library as a reusable shared component used by long-running agents, not a daemon
+
+Rules:
+- Preserve Phase 1 boundaries
+- Keep exported APIs documented
+- Keep files small and focused
+- Use context.Context only on public methods that can block or perform network I/O, consistent with the LLD
+- Return bootstrap not-implemented errors where behavior is deferred
+- Do not invent extra API surface beyond the LLD unless clearly harmless and justified
+
+After editing:
+- summarize exactly which files changed
+- explain how each changed file now aligns with the LLD
+- list which Phase 1 requirement IDs are now partially covered at API level
+- list anything still intentionally deferred to later phases

--- a/PROMPTS/01b-api-corrections.md
+++ b/PROMPTS/01b-api-corrections.md
@@ -1,4 +1,6 @@
-Read SPEC.md, REQUIREMENTS_CHECKLIST.md, and the LLD carefully.
+Read PROMPTS/IMPLEMENTATION_PROMPT.md, SPEC.md, REQUIREMENTS_CHECKLIST.md, and the LLD carefully.
+Use PROMPTS/IMPLEMENTATION_PROMPT.md as the primary implementation source of truth for code generation scope and API shape.
+Use SPEC.md as supporting design context.
 
 Revise the existing Phase 1 bootstrap only. Do not implement Phase 2 or later work.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Core NATS agent library for OLG
 
 `nats-agent-core` is a shared Go library for agents that communicate over a NATS bus.
 
-It provides common bus-facing functionality such as:
+It is intended to provide common bus-facing functionality such as:
 - NATS connection and reconnect handling
 - JetStream and Key-Value access
 - standard subject naming
@@ -32,9 +32,26 @@ In simple words:
 
 ---
 
+## Current status
+
+This repository is currently at **Phase 1 bootstrap**.
+
+The current code defines the public API surface and shared message contract only:
+- public config types
+- public client method signatures
+- standard envelope and storage models
+- typed public errors
+- logger and metrics interfaces
+
+Runtime behavior is intentionally **not implemented yet** in this phase.
+That means transport/session/KV/subject/publish-subscribe/reconnect logic is
+deferred to later phases.
+
+---
+
 ## What this library does
 
-This library helps agents:
+The intended end-state of this library is to help agents:
 
 - connect to NATS
 - reconnect after temporary disconnects
@@ -78,6 +95,9 @@ The library is designed around the idea that agents use shared transport/state h
 ---
 
 ## Basic communication model
+
+The flows below describe the target design. They are not fully implemented in
+the current Phase 1 bootstrap.
 
 ### Configure flow
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ deferred to later phases.
 
 The intended end-state of this library is to help agents:
 
+This section describes the target design and is not fully implemented in the
+current Phase 1 bootstrap.
+
 - connect to NATS
 - reconnect after temporary disconnects
 - create and use JetStream

--- a/SPEC.md
+++ b/SPEC.md
@@ -134,6 +134,22 @@ This is required so the cloud-facing side can determine:
 
 `rpc_id` alone is not sufficient for configure outcomes.
 
+### 6.4 Configure submission failure semantics
+
+Configure submission must expose clear failure outcomes:
+
+- validation failure:
+  - submission is rejected
+  - desired config is not written to KV
+  - configure notification is not published
+- KV store failure:
+  - submission fails
+  - configure notification is not published
+- notify publish failure after KV store success:
+  - submission fails with explicit publish-failure semantics
+  - desired config remains stored in KV (no implicit rollback)
+  - callers may retry notification or re-submit based on policy
+
 ---
 
 ## 7. Action contract

--- a/SPEC.md
+++ b/SPEC.md
@@ -136,6 +136,9 @@ This is required so the cloud-facing side can determine:
 
 ### 6.4 Configure submission failure semantics
 
+SubmissionAck is a direct API return value from configure submission calls.
+It is not a bus-delivered message and is not published or consumed over NATS subjects.
+
 Configure submission must expose clear failure outcomes:
 
 - validation failure:

--- a/agentcore/client.go
+++ b/agentcore/client.go
@@ -232,20 +232,6 @@ func (c *Client) LoadDesiredConfig(ctx context.Context, target string) (*StoredD
 	}
 }
 
-// LoadDesiredConfigRevision loads a specific desired-config revision later.
-func (c *Client) LoadDesiredConfigRevision(ctx context.Context, target string, revision uint64) (*StoredDesiredConfig, error) {
-	_ = ctx
-	_ = target
-	_ = revision
-
-	return nil, &Error{
-		Code:      CodeNotImplemented,
-		Op:        "load_desired_config_revision",
-		Message:   "LoadDesiredConfigRevision is not implemented in bootstrap phase",
-		Retryable: false,
-	}
-}
-
 // WatchDesiredConfig registers a desired-config watch in later phases.
 func (c *Client) WatchDesiredConfig(ctx context.Context, target string, handler DesiredConfigWatchHandler) (StopFunc, error) {
 	_ = ctx

--- a/agentcore/client.go
+++ b/agentcore/client.go
@@ -1,0 +1,331 @@
+package agentcore
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ConfigureHandler handles configure notifications for a target.
+type ConfigureHandler func(context.Context, ConfigureNotification) error
+
+// ActionHandler handles action commands for a target and action name.
+type ActionHandler func(context.Context, ActionCommand) error
+
+// ResultHandler handles result messages for a target.
+type ResultHandler func(context.Context, ResultEnvelope) error
+
+// StatusHandler handles status messages for a target.
+type StatusHandler func(context.Context, StatusEnvelope) error
+
+// DesiredConfigWatchHandler handles desired-config watch updates.
+type DesiredConfigWatchHandler func(context.Context, StoredDesiredConfig) error
+
+// StopFunc stops a watch registration created by a public API.
+type StopFunc func() error
+
+// SubscriptionOption configures a public subscription registration.
+type SubscriptionOption func(*SubscriptionOptions)
+
+// SubscriptionOptions contains public subscription registration settings.
+type SubscriptionOptions struct {
+	QueueGroup string
+}
+
+type clientOptions struct {
+	logger    Logger
+	metrics   Metrics
+	now       func() time.Time
+	errorSink func(error)
+}
+
+// Option applies an optional public client setting during construction.
+type Option func(*clientOptions) error
+
+// WithLogger injects a logger into the client.
+func WithLogger(l Logger) Option {
+	return func(opts *clientOptions) error {
+		opts.logger = l
+		return nil
+	}
+}
+
+// WithMetrics injects metrics hooks into the client.
+func WithMetrics(m Metrics) Option {
+	return func(opts *clientOptions) error {
+		opts.metrics = m
+		return nil
+	}
+}
+
+// WithClock overrides the clock used by bootstrap defaults.
+func WithClock(now func() time.Time) Option {
+	return func(opts *clientOptions) error {
+		if now == nil {
+			return &Error{Code: CodeValidation, Op: "with_clock", Message: "clock function is nil"}
+		}
+		opts.now = now
+		return nil
+	}
+}
+
+// WithErrorSink injects a best-effort async error sink hook.
+func WithErrorSink(fn func(error)) Option {
+	return func(opts *clientOptions) error {
+		opts.errorSink = fn
+		return nil
+	}
+}
+
+// Client is the public facade used by agent processes.
+type Client struct {
+	mu      sync.RWMutex
+	cfg     Config
+	health  HealthSnapshot
+	options clientOptions
+}
+
+// New validates public options and constructs a bootstrap client facade.
+func New(cfg Config, opts ...Option) (*Client, error) {
+	options := clientOptions{
+		now: time.Now,
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(&options); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Client{
+		cfg: cfg,
+		health: HealthSnapshot{
+			State: StateNew,
+		},
+		options: options,
+	}, nil
+}
+
+// Config returns the bootstrap configuration snapshot.
+func (c *Client) Config() Config {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.cfg
+}
+
+// Start begins the client lifecycle. Transport/session setup is deferred.
+func (c *Client) Start(ctx context.Context) error {
+	_ = ctx
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.health.State = StateConnecting
+
+	return &Error{
+		Code:      CodeNotImplemented,
+		Op:        "start",
+		Message:   "Start is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// Close ends the client lifecycle. Drain behavior is deferred.
+func (c *Client) Close(ctx context.Context) error {
+	_ = ctx
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.health.State = StateDraining
+
+	return &Error{
+		Code:      CodeNotImplemented,
+		Op:        "close",
+		Message:   "Close is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// Health returns the latest public health snapshot.
+func (c *Client) Health() HealthSnapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.health
+}
+
+// SubmitConfigure accepts a configure command for later-phase transport logic.
+func (c *Client) SubmitConfigure(ctx context.Context, cmd ConfigureCommand) (*SubmissionAck, error) {
+	_ = ctx
+	_ = cmd
+
+	return nil, &Error{
+		Code:      CodeNotImplemented,
+		Op:        "submit_configure",
+		Message:   "SubmitConfigure is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// SubmitAction accepts an action command for later-phase transport logic.
+func (c *Client) SubmitAction(ctx context.Context, cmd ActionCommand) (*SubmissionAck, error) {
+	_ = ctx
+	_ = cmd
+
+	return nil, &Error{
+		Code:      CodeNotImplemented,
+		Op:        "submit_action",
+		Message:   "SubmitAction is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// PublishResult publishes a result envelope in later phases.
+func (c *Client) PublishResult(ctx context.Context, msg ResultEnvelope) error {
+	_ = ctx
+	_ = msg
+
+	return &Error{
+		Code:      CodeNotImplemented,
+		Op:        "publish_result",
+		Message:   "PublishResult is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// PublishStatus publishes a status envelope in later phases.
+func (c *Client) PublishStatus(ctx context.Context, msg StatusEnvelope) error {
+	_ = ctx
+	_ = msg
+
+	return &Error{
+		Code:      CodeNotImplemented,
+		Op:        "publish_status",
+		Message:   "PublishStatus is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// StoreDesiredConfig writes desired configuration in later phases.
+func (c *Client) StoreDesiredConfig(ctx context.Context, rec DesiredConfigRecord) (*StoredDesiredConfig, error) {
+	_ = ctx
+	_ = rec
+
+	return nil, &Error{
+		Code:      CodeNotImplemented,
+		Op:        "store_desired_config",
+		Message:   "StoreDesiredConfig is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// LoadDesiredConfig loads desired configuration in later phases.
+func (c *Client) LoadDesiredConfig(ctx context.Context, target string) (*StoredDesiredConfig, error) {
+	_ = ctx
+	_ = target
+
+	return nil, &Error{
+		Code:      CodeNotImplemented,
+		Op:        "load_desired_config",
+		Message:   "LoadDesiredConfig is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// LoadDesiredConfigRevision loads a specific desired-config revision later.
+func (c *Client) LoadDesiredConfigRevision(ctx context.Context, target string, revision uint64) (*StoredDesiredConfig, error) {
+	_ = ctx
+	_ = target
+	_ = revision
+
+	return nil, &Error{
+		Code:      CodeNotImplemented,
+		Op:        "load_desired_config_revision",
+		Message:   "LoadDesiredConfigRevision is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// WatchDesiredConfig registers a desired-config watch in later phases.
+func (c *Client) WatchDesiredConfig(ctx context.Context, target string, handler DesiredConfigWatchHandler) (StopFunc, error) {
+	_ = ctx
+	_ = target
+	_ = handler
+
+	return nil, &Error{
+		Code:      CodeNotImplemented,
+		Op:        "watch_desired_config",
+		Message:   "WatchDesiredConfig is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// StartupReconcile loads latest desired state during recovery in later phases.
+func (c *Client) StartupReconcile(ctx context.Context, target string) (*StoredDesiredConfig, error) {
+	_ = ctx
+	_ = target
+
+	return nil, &Error{
+		Code:      CodeNotImplemented,
+		Op:        "startup_reconcile",
+		Message:   "StartupReconcile is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// RegisterConfigureHandler registers a configure notification handler.
+func (c *Client) RegisterConfigureHandler(target string, handler ConfigureHandler, opts ...SubscriptionOption) error {
+	_ = target
+	_ = handler
+	_ = opts
+
+	return &Error{
+		Code:      CodeNotImplemented,
+		Op:        "register_configure_handler",
+		Message:   "RegisterConfigureHandler is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// RegisterActionHandler registers a target/action handler.
+func (c *Client) RegisterActionHandler(target, action string, handler ActionHandler, opts ...SubscriptionOption) error {
+	_ = target
+	_ = action
+	_ = handler
+	_ = opts
+
+	return &Error{
+		Code:      CodeNotImplemented,
+		Op:        "register_action_handler",
+		Message:   "RegisterActionHandler is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// RegisterResultHandler registers a result handler.
+func (c *Client) RegisterResultHandler(target string, handler ResultHandler, opts ...SubscriptionOption) error {
+	_ = target
+	_ = handler
+	_ = opts
+
+	return &Error{
+		Code:      CodeNotImplemented,
+		Op:        "register_result_handler",
+		Message:   "RegisterResultHandler is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}
+
+// RegisterStatusHandler registers a status handler.
+func (c *Client) RegisterStatusHandler(target string, handler StatusHandler, opts ...SubscriptionOption) error {
+	_ = target
+	_ = handler
+	_ = opts
+
+	return &Error{
+		Code:      CodeNotImplemented,
+		Op:        "register_status_handler",
+		Message:   "RegisterStatusHandler is not implemented in bootstrap phase",
+		Retryable: false,
+	}
+}

--- a/agentcore/client_test.go
+++ b/agentcore/client_test.go
@@ -1,0 +1,107 @@
+package agentcore
+
+import "testing"
+
+// TestNewCreatesClientWithInitialState verifies that New(...) successfully
+// constructs a client from the provided config, initializes the client health
+// to StateNew, and preserves the configured public settings exactly as passed in.
+//
+// In Phase 1, New(...) does not yet perform full transport/session setup.
+// So this test focuses only on constructor behavior that is actually implemented:
+//   - client creation succeeds
+//   - no error is returned
+//   - initial health state is StateNew
+//   - Config() returns the same config values that were provided to New(...)
+// How To Run -
+//     go test -v ./agentcore -run TestNewCreatesClientWithInitialState
+// Results -
+//     === RUN   TestNewCreatesClientWithInitialState
+//     --- PASS: TestNewCreatesClientWithInitialState (0.00s)
+//     PASS
+//     ok  	github.com/routerarchitects/nats-agent-core/agentcore	0.002s
+
+func TestNewCreatesClientWithInitialState(t *testing.T) {
+	cfg := Config{
+		AgentName: "test-agent",
+		Version:   "1.0",
+		NATS: NATSConfig{
+			Servers: []string{"nats://localhost:4222"},
+		},
+		JetStream: JetStreamConfig{},
+		Subjects: SubjectConfig{
+			ConfigurePattern: "cmd.configure.%s",
+			ActionPattern:    "cmd.action.%s.%s",
+			ResultPattern:    "result.%s",
+			StatusPattern:    "status.%s",
+			HealthPattern:    "health.%s",
+		},
+		KV: KVConfig{
+			Bucket:     "cfg_desired",
+			KeyPattern: "desired.%s",
+		},
+	}
+
+	client, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("New returned nil client")
+	}
+
+	health := client.Health()
+	if health.State != StateNew {
+		t.Fatalf("expected initial health state %q, got %q", StateNew, health.State)
+	}
+
+	gotCfg := client.Config()
+
+	if gotCfg.AgentName != cfg.AgentName {
+		t.Fatalf("expected AgentName %q, got %q", cfg.AgentName, gotCfg.AgentName)
+	}
+	if gotCfg.Version != cfg.Version {
+		t.Fatalf("expected Version %q, got %q", cfg.Version, gotCfg.Version)
+	}
+
+	if len(gotCfg.NATS.Servers) != len(cfg.NATS.Servers) {
+		t.Fatalf("expected %d NATS servers, got %d", len(cfg.NATS.Servers), len(gotCfg.NATS.Servers))
+	}
+	for i := range cfg.NATS.Servers {
+		if gotCfg.NATS.Servers[i] != cfg.NATS.Servers[i] {
+			t.Fatalf("expected NATS server %q at index %d, got %q", cfg.NATS.Servers[i], i, gotCfg.NATS.Servers[i])
+		}
+	}
+
+	if gotCfg.JetStream.Domain != cfg.JetStream.Domain {
+		t.Fatalf("expected JetStream Domain %q, got %q", cfg.JetStream.Domain, gotCfg.JetStream.Domain)
+	}
+	if gotCfg.JetStream.APIPrefix != cfg.JetStream.APIPrefix {
+		t.Fatalf("expected JetStream APIPrefix %q, got %q", cfg.JetStream.APIPrefix, gotCfg.JetStream.APIPrefix)
+	}
+	if gotCfg.JetStream.DefaultTimeout != cfg.JetStream.DefaultTimeout {
+		t.Fatalf("expected JetStream DefaultTimeout %v, got %v", cfg.JetStream.DefaultTimeout, gotCfg.JetStream.DefaultTimeout)
+	}
+
+	if gotCfg.Subjects.ConfigurePattern != cfg.Subjects.ConfigurePattern {
+		t.Fatalf("expected ConfigurePattern %q, got %q", cfg.Subjects.ConfigurePattern, gotCfg.Subjects.ConfigurePattern)
+	}
+	if gotCfg.Subjects.ActionPattern != cfg.Subjects.ActionPattern {
+		t.Fatalf("expected ActionPattern %q, got %q", cfg.Subjects.ActionPattern, gotCfg.Subjects.ActionPattern)
+	}
+	if gotCfg.Subjects.ResultPattern != cfg.Subjects.ResultPattern {
+		t.Fatalf("expected ResultPattern %q, got %q", cfg.Subjects.ResultPattern, gotCfg.Subjects.ResultPattern)
+	}
+	if gotCfg.Subjects.StatusPattern != cfg.Subjects.StatusPattern {
+		t.Fatalf("expected StatusPattern %q, got %q", cfg.Subjects.StatusPattern, gotCfg.Subjects.StatusPattern)
+	}
+	if gotCfg.Subjects.HealthPattern != cfg.Subjects.HealthPattern {
+		t.Fatalf("expected HealthPattern %q, got %q", cfg.Subjects.HealthPattern, gotCfg.Subjects.HealthPattern)
+	}
+
+	if gotCfg.KV.Bucket != cfg.KV.Bucket {
+		t.Fatalf("expected KV Bucket %q, got %q", cfg.KV.Bucket, gotCfg.KV.Bucket)
+	}
+	if gotCfg.KV.KeyPattern != cfg.KV.KeyPattern {
+		t.Fatalf("expected KV KeyPattern %q, got %q", cfg.KV.KeyPattern, gotCfg.KV.KeyPattern)
+	}
+}

--- a/agentcore/client_test.go
+++ b/agentcore/client_test.go
@@ -630,3 +630,31 @@ func TestBootstrapStubMethodsReturnCodeNotImplemented(t *testing.T) {
 		})
 	}
 }
+
+/*
+TC-CLIENT-008
+Type: Positive
+Title: New tolerates a nil constructor option
+Summary:
+Verifies that New(...) safely ignores a nil option entry in the variadic option
+list. This is intentional bootstrap behavior in the current implementation.
+
+Validates:
+  - New(cfg, nil) does not panic
+  - New(cfg, nil) does not return an error
+  - returned client is non-nil
+  - initial health state remains StateNew
+*/
+func TestNewToleratesNilOption(t *testing.T) {
+	client, err := New(testConfig(), nil)
+	if err != nil {
+		t.Fatalf("New returned unexpected error for nil option: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client, got nil")
+	}
+
+	if got := client.Health().State; got != StateNew {
+		t.Fatalf("expected initial health state %q, got %q", StateNew, got)
+	}
+}

--- a/agentcore/client_test.go
+++ b/agentcore/client_test.go
@@ -1,33 +1,52 @@
 package agentcore
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
 
-// TestNewCreatesClientWithInitialState verifies that New(...) successfully
-// constructs a client from the provided config, initializes the client health
-// to StateNew, and preserves the configured public settings exactly as passed in.
-//
-// In Phase 1, New(...) does not yet perform full transport/session setup.
-// So this test focuses only on constructor behavior that is actually implemented:
-//   - client creation succeeds
-//   - no error is returned
-//   - initial health state is StateNew
-//   - Config() returns the same config values that were provided to New(...)
-// How To Run -
-//     go test -v ./agentcore -run TestNewCreatesClientWithInitialState
-// Results -
-//     === RUN   TestNewCreatesClientWithInitialState
-//     --- PASS: TestNewCreatesClientWithInitialState (0.00s)
-//     PASS
-//     ok  	github.com/routerarchitects/nats-agent-core/agentcore	0.002s
+type testLogger struct {
+	entries []string
+}
 
-func TestNewCreatesClientWithInitialState(t *testing.T) {
-	cfg := Config{
+func (l *testLogger) Debug(msg string, kv ...any) { l.entries = append(l.entries, "DEBUG:"+msg) }
+func (l *testLogger) Info(msg string, kv ...any)  { l.entries = append(l.entries, "INFO:"+msg) }
+func (l *testLogger) Warn(msg string, kv ...any)  { l.entries = append(l.entries, "WARN:"+msg) }
+func (l *testLogger) Error(msg string, kv ...any) { l.entries = append(l.entries, "ERROR:"+msg) }
+
+type testMetrics struct {
+	connectCalls int
+	states       []string
+}
+
+func (m *testMetrics) IncConnect(result string)                           { m.connectCalls++ }
+func (m *testMetrics) SetConnectionState(state string)                    { m.states = append(m.states, state) }
+func (m *testMetrics) IncPublish(kind, subject, result string)            {}
+func (m *testMetrics) ObservePublishLatency(kind, subject string, d time.Duration) {}
+func (m *testMetrics) IncSubscribe(kind, subject, result string)          {}
+func (m *testMetrics) IncKV(op, result string)                            {}
+
+func testConfig() Config {
+	return Config{
 		AgentName: "test-agent",
 		Version:   "1.0",
 		NATS: NATSConfig{
-			Servers: []string{"nats://localhost:4222"},
+			Servers:              []string{"nats://localhost:4222"},
+			ClientName:           "agentcore-test",
+			ConnectTimeout:       3 * time.Second,
+			RetryOnFailedConnect: true,
+			MaxReconnects:        5,
+			ReconnectWait:        500 * time.Millisecond,
+			ReconnectBufSize:     1024,
 		},
-		JetStream: JetStreamConfig{},
+		JetStream: JetStreamConfig{
+			Domain:         "test-domain",
+			APIPrefix:      "$JS.API",
+			DefaultTimeout: 2 * time.Second,
+		},
 		Subjects: SubjectConfig{
 			ConfigurePattern: "cmd.configure.%s",
 			ActionPattern:    "cmd.action.%s.%s",
@@ -36,10 +55,67 @@ func TestNewCreatesClientWithInitialState(t *testing.T) {
 			HealthPattern:    "health.%s",
 		},
 		KV: KVConfig{
-			Bucket:     "cfg_desired",
-			KeyPattern: "desired.%s",
+			Bucket:           "cfg_desired",
+			KeyPattern:       "desired.%s",
+			AutoCreateBucket: true,
+			History:          5,
+			TTL:              30 * time.Minute,
+			MaxValueSize:     4096,
+			Storage:          "file",
+			Replicas:         1,
+		},
+		Timeouts: TimeoutConfig{
+			PublishTimeout:   1 * time.Second,
+			SubscribeTimeout: 1 * time.Second,
+			KVTimeout:        1 * time.Second,
+			ShutdownTimeout:  2 * time.Second,
+			HandlerWarnAfter: 500 * time.Millisecond,
+		},
+		Retry: RetryConfig{
+			PublishAttempts: 3,
+			PublishBackoff:  100 * time.Millisecond,
+		},
+		Execution: ExecutionConfig{
+			HandlerMode: "sync",
 		},
 	}
+}
+
+func requireNotImplementedError(t *testing.T, err error, wantOp string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+
+	var got *Error
+	if !errors.As(err, &got) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if got.Code != CodeNotImplemented {
+		t.Fatalf("expected error code %q, got %q", CodeNotImplemented, got.Code)
+	}
+	if got.Op != wantOp {
+		t.Fatalf("expected error op %q, got %q", wantOp, got.Op)
+	}
+}
+
+/*
+TC-CLIENT-001
+Type: Positive
+Title: New creates client with initial bootstrap state
+Summary:
+Verifies that New(...) constructs a client successfully, initializes health to
+StateNew, and preserves the caller-provided config values exactly as passed in.
+
+Validates:
+  - constructor succeeds without error
+  - returned client is non-nil
+  - initial health state is StateNew
+  - Config() returns the same public config values supplied to New(...)
+*/
+func TestNewCreatesClientWithInitialState(t *testing.T) {
+	cfg := testConfig()
 
 	client, err := New(cfg)
 	if err != nil {
@@ -70,6 +146,25 @@ func TestNewCreatesClientWithInitialState(t *testing.T) {
 		if gotCfg.NATS.Servers[i] != cfg.NATS.Servers[i] {
 			t.Fatalf("expected NATS server %q at index %d, got %q", cfg.NATS.Servers[i], i, gotCfg.NATS.Servers[i])
 		}
+	}
+
+	if gotCfg.NATS.ClientName != cfg.NATS.ClientName {
+		t.Fatalf("expected ClientName %q, got %q", cfg.NATS.ClientName, gotCfg.NATS.ClientName)
+	}
+	if gotCfg.NATS.ConnectTimeout != cfg.NATS.ConnectTimeout {
+		t.Fatalf("expected ConnectTimeout %v, got %v", cfg.NATS.ConnectTimeout, gotCfg.NATS.ConnectTimeout)
+	}
+	if gotCfg.NATS.RetryOnFailedConnect != cfg.NATS.RetryOnFailedConnect {
+		t.Fatalf("expected RetryOnFailedConnect %v, got %v", cfg.NATS.RetryOnFailedConnect, gotCfg.NATS.RetryOnFailedConnect)
+	}
+	if gotCfg.NATS.MaxReconnects != cfg.NATS.MaxReconnects {
+		t.Fatalf("expected MaxReconnects %d, got %d", cfg.NATS.MaxReconnects, gotCfg.NATS.MaxReconnects)
+	}
+	if gotCfg.NATS.ReconnectWait != cfg.NATS.ReconnectWait {
+		t.Fatalf("expected ReconnectWait %v, got %v", cfg.NATS.ReconnectWait, gotCfg.NATS.ReconnectWait)
+	}
+	if gotCfg.NATS.ReconnectBufSize != cfg.NATS.ReconnectBufSize {
+		t.Fatalf("expected ReconnectBufSize %d, got %d", cfg.NATS.ReconnectBufSize, gotCfg.NATS.ReconnectBufSize)
 	}
 
 	if gotCfg.JetStream.Domain != cfg.JetStream.Domain {
@@ -103,5 +198,435 @@ func TestNewCreatesClientWithInitialState(t *testing.T) {
 	}
 	if gotCfg.KV.KeyPattern != cfg.KV.KeyPattern {
 		t.Fatalf("expected KV KeyPattern %q, got %q", cfg.KV.KeyPattern, gotCfg.KV.KeyPattern)
+	}
+	if gotCfg.KV.AutoCreateBucket != cfg.KV.AutoCreateBucket {
+		t.Fatalf("expected AutoCreateBucket %v, got %v", cfg.KV.AutoCreateBucket, gotCfg.KV.AutoCreateBucket)
+	}
+	if gotCfg.KV.History != cfg.KV.History {
+		t.Fatalf("expected History %d, got %d", cfg.KV.History, gotCfg.KV.History)
+	}
+	if gotCfg.KV.TTL != cfg.KV.TTL {
+		t.Fatalf("expected TTL %v, got %v", cfg.KV.TTL, gotCfg.KV.TTL)
+	}
+	if gotCfg.KV.MaxValueSize != cfg.KV.MaxValueSize {
+		t.Fatalf("expected MaxValueSize %d, got %d", cfg.KV.MaxValueSize, gotCfg.KV.MaxValueSize)
+	}
+	if gotCfg.KV.Storage != cfg.KV.Storage {
+		t.Fatalf("expected Storage %q, got %q", cfg.KV.Storage, gotCfg.KV.Storage)
+	}
+	if gotCfg.KV.Replicas != cfg.KV.Replicas {
+		t.Fatalf("expected Replicas %d, got %d", cfg.KV.Replicas, gotCfg.KV.Replicas)
+	}
+
+	if gotCfg.Timeouts.PublishTimeout != cfg.Timeouts.PublishTimeout {
+		t.Fatalf("expected PublishTimeout %v, got %v", cfg.Timeouts.PublishTimeout, gotCfg.Timeouts.PublishTimeout)
+	}
+	if gotCfg.Timeouts.SubscribeTimeout != cfg.Timeouts.SubscribeTimeout {
+		t.Fatalf("expected SubscribeTimeout %v, got %v", cfg.Timeouts.SubscribeTimeout, gotCfg.Timeouts.SubscribeTimeout)
+	}
+	if gotCfg.Timeouts.KVTimeout != cfg.Timeouts.KVTimeout {
+		t.Fatalf("expected KVTimeout %v, got %v", cfg.Timeouts.KVTimeout, gotCfg.Timeouts.KVTimeout)
+	}
+	if gotCfg.Timeouts.ShutdownTimeout != cfg.Timeouts.ShutdownTimeout {
+		t.Fatalf("expected ShutdownTimeout %v, got %v", cfg.Timeouts.ShutdownTimeout, gotCfg.Timeouts.ShutdownTimeout)
+	}
+	if gotCfg.Timeouts.HandlerWarnAfter != cfg.Timeouts.HandlerWarnAfter {
+		t.Fatalf("expected HandlerWarnAfter %v, got %v", cfg.Timeouts.HandlerWarnAfter, gotCfg.Timeouts.HandlerWarnAfter)
+	}
+
+	if gotCfg.Retry.PublishAttempts != cfg.Retry.PublishAttempts {
+		t.Fatalf("expected PublishAttempts %d, got %d", cfg.Retry.PublishAttempts, gotCfg.Retry.PublishAttempts)
+	}
+	if gotCfg.Retry.PublishBackoff != cfg.Retry.PublishBackoff {
+		t.Fatalf("expected PublishBackoff %v, got %v", cfg.Retry.PublishBackoff, gotCfg.Retry.PublishBackoff)
+	}
+
+	if gotCfg.Execution.HandlerMode != cfg.Execution.HandlerMode {
+		t.Fatalf("expected HandlerMode %q, got %q", cfg.Execution.HandlerMode, gotCfg.Execution.HandlerMode)
+	}
+}
+
+/*
+TC-CLIENT-002
+Type: Positive
+Title: Health returns the expected zeroed bootstrap snapshot
+Summary:
+Verifies that a newly created client exposes the expected initial health state
+and zero-value health counters/flags before any runtime transport work exists.
+
+Validates:
+  - Health().State starts at StateNew
+  - JetStreamReady and KVReady are false
+  - subscription counters start at zero
+  - LastError and ConnectedURL are empty
+*/
+func TestHealthReturnsBootstrapSnapshot(t *testing.T) {
+	client, err := New(testConfig())
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	got := client.Health()
+
+	if got.State != StateNew {
+		t.Fatalf("expected state %q, got %q", StateNew, got.State)
+	}
+	if got.JetStreamReady {
+		t.Fatal("expected JetStreamReady to be false at bootstrap")
+	}
+	if got.KVReady {
+		t.Fatal("expected KVReady to be false at bootstrap")
+	}
+	if got.RegisteredSubscriptions != 0 {
+		t.Fatalf("expected RegisteredSubscriptions 0, got %d", got.RegisteredSubscriptions)
+	}
+	if got.ActiveSubscriptions != 0 {
+		t.Fatalf("expected ActiveSubscriptions 0, got %d", got.ActiveSubscriptions)
+	}
+	if got.LastError != "" {
+		t.Fatalf("expected empty LastError, got %q", got.LastError)
+	}
+	if got.ConnectedURL != "" {
+		t.Fatalf("expected empty ConnectedURL, got %q", got.ConnectedURL)
+	}
+}
+
+/*
+TC-CLIENT-003
+Type: Positive
+Title: Constructor applies optional logger, metrics, clock, and error sink hooks
+Summary:
+Verifies that supported Phase 1 constructor options are accepted and stored on
+the client facade without requiring transport/runtime setup.
+
+Validates:
+  - WithLogger stores the provided logger
+  - WithMetrics stores the provided metrics hook
+  - WithClock stores the provided clock function
+  - WithErrorSink stores the provided async error sink hook
+*/
+func TestNewAppliesConstructorOptions(t *testing.T) {
+	logger := &testLogger{}
+	metrics := &testMetrics{}
+	fixedNow := func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	sinkCalls := 0
+	var sinkErr error
+	sink := func(err error) {
+		sinkCalls++
+		sinkErr = err
+	}
+
+	client, err := New(
+		testConfig(),
+		WithLogger(logger),
+		WithMetrics(metrics),
+		WithClock(fixedNow),
+		WithErrorSink(sink),
+	)
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	if client.options.logger != logger {
+		t.Fatal("expected logger option to be stored on client")
+	}
+	if client.options.metrics != metrics {
+		t.Fatal("expected metrics option to be stored on client")
+	}
+	if client.options.now == nil {
+		t.Fatal("expected clock option to be stored on client")
+	}
+	if got := client.options.now(); !got.Equal(fixedNow()) {
+		t.Fatalf("expected stored clock value %v, got %v", fixedNow(), got)
+	}
+	if client.options.errorSink == nil {
+		t.Fatal("expected error sink option to be stored on client")
+	}
+
+	wantErr := errors.New("sink-test")
+	client.options.errorSink(wantErr)
+	if sinkCalls != 1 {
+		t.Fatalf("expected error sink to be called once, got %d", sinkCalls)
+	}
+	if !errors.Is(sinkErr, wantErr) {
+		t.Fatalf("expected sink error %v, got %v", wantErr, sinkErr)
+	}
+}
+
+/*
+TC-CLIENT-004
+Type: Negative
+Title: WithClock rejects a nil clock function
+Summary:
+Verifies that bootstrap option validation rejects a nil clock override and
+returns a typed validation error.
+
+Validates:
+  - New(...) fails when WithClock(nil) is supplied
+  - returned error is typed as *Error
+  - error code is CodeValidation
+  - error op is with_clock
+*/
+func TestWithClockRejectsNilFunction(t *testing.T) {
+	_, err := New(testConfig(), WithClock(nil))
+	if err == nil {
+		t.Fatal("expected error from WithClock(nil), got nil")
+	}
+
+	var got *Error
+	if !errors.As(err, &got) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if got.Code != CodeValidation {
+		t.Fatalf("expected error code %q, got %q", CodeValidation, got.Code)
+	}
+	if got.Op != "with_clock" {
+		t.Fatalf("expected error op %q, got %q", "with_clock", got.Op)
+	}
+}
+
+/*
+TC-CLIENT-005
+Type: Negative
+Title: Start returns bootstrap not-implemented error
+Summary:
+Verifies that Start(...) remains a Phase 1 stub and returns the expected typed
+not-implemented error while updating the health state to connecting.
+
+Validates:
+  - Start(...) returns a non-nil *Error
+  - error code is CodeNotImplemented
+  - error op is start
+  - health state transitions to StateConnecting
+*/
+func TestStartReturnsNotImplementedAndMovesHealthToConnecting(t *testing.T) {
+	client, err := New(testConfig())
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	err = client.Start(context.Background())
+	requireNotImplementedError(t, err, "start")
+
+	if got := client.Health().State; got != StateConnecting {
+		t.Fatalf("expected health state %q, got %q", StateConnecting, got)
+	}
+}
+
+/*
+TC-CLIENT-006
+Type: Negative
+Title: Close returns bootstrap not-implemented error
+Summary:
+Verifies that Close(...) remains a Phase 1 stub and returns the expected typed
+not-implemented error while updating the health state to draining.
+
+Validates:
+  - Close(...) returns a non-nil *Error
+  - error code is CodeNotImplemented
+  - error op is close
+  - health state transitions to StateDraining
+*/
+func TestCloseReturnsNotImplementedAndMovesHealthToDraining(t *testing.T) {
+	client, err := New(testConfig())
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	err = client.Close(context.Background())
+	requireNotImplementedError(t, err, "close")
+
+	if got := client.Health().State; got != StateDraining {
+		t.Fatalf("expected health state %q, got %q", StateDraining, got)
+	}
+}
+
+/*
+TC-CLIENT-007
+Type: Negative
+Title: Bootstrap stubs return CodeNotImplemented across deferred APIs
+Summary:
+Verifies that the Phase 1 APIs intentionally deferred to later transport/runtime
+phases return consistent typed not-implemented errors and no success value.
+
+Validates:
+  - each deferred public API returns a non-nil *Error
+  - each returned *Error has CodeNotImplemented
+  - each error carries the correct operation name
+  - methods that return values do not return success payloads in Phase 1
+*/
+func TestBootstrapStubMethodsReturnCodeNotImplemented(t *testing.T) {
+	client, err := New(testConfig())
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	now := time.Unix(1700000001, 0).UTC()
+
+	cfgCmd := ConfigureCommand{
+		Version:   "1.0",
+		RPCID:     "rpc-config-1",
+		Target:    "vyos",
+		UUID:      "cfg-1",
+		Payload:   json.RawMessage(`{"hostname":"router-1"}`),
+		Timestamp: now,
+	}
+	actionCmd := ActionCommand{
+		Version:     "1.0",
+		RPCID:       "rpc-action-1",
+		Target:      "vyos",
+		CommandType: "action",
+		Action:      "trace",
+		Payload:     json.RawMessage(`{"destination":"8.8.8.8"}`),
+		Timestamp:   now,
+	}
+	resultMsg := ResultEnvelope{
+		Version:     "1.0",
+		RPCID:       "rpc-result-1",
+		Target:      "vyos",
+		CommandType: "configure",
+		UUID:        "cfg-1",
+		Result:      "success",
+		Timestamp:   now,
+	}
+	statusMsg := StatusEnvelope{
+		Version:   "1.0",
+		RPCID:     "rpc-status-1",
+		Target:    "vyos",
+		Status:    "running",
+		Timestamp: now,
+	}
+	record := DesiredConfigRecord{
+		Version:   "1.0",
+		RPCID:     "rpc-store-1",
+		Target:    "vyos",
+		UUID:      "cfg-2",
+		Payload:   json.RawMessage(`{"interfaces":[]}`),
+		Timestamp: now,
+	}
+
+	tests := []struct {
+		name string
+		op   string
+		call func(*Client) error
+	}{
+		{
+			name: "SubmitConfigure",
+			op:   "submit_configure",
+			call: func(c *Client) error {
+				ack, err := c.SubmitConfigure(context.Background(), cfgCmd)
+				if ack != nil {
+					t.Fatalf("expected nil SubmissionAck, got %#v", ack)
+				}
+				return err
+			},
+		},
+		{
+			name: "SubmitAction",
+			op:   "submit_action",
+			call: func(c *Client) error {
+				ack, err := c.SubmitAction(context.Background(), actionCmd)
+				if ack != nil {
+					t.Fatalf("expected nil SubmissionAck, got %#v", ack)
+				}
+				return err
+			},
+		},
+		{
+			name: "PublishResult",
+			op:   "publish_result",
+			call: func(c *Client) error {
+				return c.PublishResult(context.Background(), resultMsg)
+			},
+		},
+		{
+			name: "PublishStatus",
+			op:   "publish_status",
+			call: func(c *Client) error {
+				return c.PublishStatus(context.Background(), statusMsg)
+			},
+		},
+		{
+			name: "StoreDesiredConfig",
+			op:   "store_desired_config",
+			call: func(c *Client) error {
+				stored, err := c.StoreDesiredConfig(context.Background(), record)
+				if stored != nil {
+					t.Fatalf("expected nil StoredDesiredConfig, got %#v", stored)
+				}
+				return err
+			},
+		},
+		{
+			name: "LoadDesiredConfig",
+			op:   "load_desired_config",
+			call: func(c *Client) error {
+				stored, err := c.LoadDesiredConfig(context.Background(), "vyos")
+				if stored != nil {
+					t.Fatalf("expected nil StoredDesiredConfig, got %#v", stored)
+				}
+				return err
+			},
+		},
+		{
+			name: "WatchDesiredConfig",
+			op:   "watch_desired_config",
+			call: func(c *Client) error {
+				stop, err := c.WatchDesiredConfig(context.Background(), "vyos", func(context.Context, StoredDesiredConfig) error {
+					return nil
+				})
+				if stop != nil {
+					t.Fatal("expected nil StopFunc for bootstrap watch")
+				}
+				return err
+			},
+		},
+		{
+			name: "StartupReconcile",
+			op:   "startup_reconcile",
+			call: func(c *Client) error {
+				stored, err := c.StartupReconcile(context.Background(), "vyos")
+				if stored != nil {
+					t.Fatalf("expected nil StoredDesiredConfig, got %#v", stored)
+				}
+				return err
+			},
+		},
+		{
+			name: "RegisterConfigureHandler",
+			op:   "register_configure_handler",
+			call: func(c *Client) error {
+				return c.RegisterConfigureHandler("vyos", func(context.Context, ConfigureNotification) error { return nil })
+			},
+		},
+		{
+			name: "RegisterActionHandler",
+			op:   "register_action_handler",
+			call: func(c *Client) error {
+				return c.RegisterActionHandler("vyos", "trace", func(context.Context, ActionCommand) error { return nil })
+			},
+		},
+		{
+			name: "RegisterResultHandler",
+			op:   "register_result_handler",
+			call: func(c *Client) error {
+				return c.RegisterResultHandler("vyos", func(context.Context, ResultEnvelope) error { return nil })
+			},
+		},
+		{
+			name: "RegisterStatusHandler",
+			op:   "register_status_handler",
+			call: func(c *Client) error {
+				return c.RegisterStatusHandler("vyos", func(context.Context, StatusEnvelope) error { return nil })
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call(client)
+			requireNotImplementedError(t, err, tc.op)
+		})
 	}
 }

--- a/agentcore/config.go
+++ b/agentcore/config.go
@@ -1,0 +1,100 @@
+package agentcore
+
+import "time"
+
+// Config configures the reusable agentcore library used inside long-running
+// agent processes.
+type Config struct {
+	AgentName string          `json:"agent_name"`
+	Version   string          `json:"version"`
+	NATS      NATSConfig      `json:"nats"`
+	JetStream JetStreamConfig `json:"jetstream"`
+	Subjects  SubjectConfig   `json:"subjects"`
+	KV        KVConfig        `json:"kv"`
+	Timeouts  TimeoutConfig   `json:"timeouts"`
+	Retry     RetryConfig     `json:"retry"`
+	Execution ExecutionConfig `json:"execution"`
+	Observe   ObserveConfig   `json:"observe,omitempty"`
+}
+
+// NATSConfig contains core NATS connectivity settings.
+type NATSConfig struct {
+	Servers              []string      `json:"servers"`
+	ClientName           string        `json:"client_name,omitempty"`
+	CredentialsFile      string        `json:"credentials_file,omitempty"`
+	NKeySeedFile         string        `json:"nkey_seed_file,omitempty"`
+	UserJWTFile          string        `json:"user_jwt_file,omitempty"`
+	Username             string        `json:"username,omitempty"`
+	Password             string        `json:"password,omitempty"`
+	Token                string        `json:"token,omitempty"`
+	ConnectTimeout       time.Duration `json:"connect_timeout,omitempty"`
+	RetryOnFailedConnect bool          `json:"retry_on_failed_connect,omitempty"`
+	MaxReconnects        int           `json:"max_reconnects,omitempty"`
+	ReconnectWait        time.Duration `json:"reconnect_wait,omitempty"`
+	ReconnectBufSize     int           `json:"reconnect_buf_size,omitempty"`
+	TLS                  *TLSConfig    `json:"tls,omitempty"`
+}
+
+// TLSConfig contains public TLS configuration for the NATS connection.
+type TLSConfig struct {
+	Enabled            bool   `json:"enabled,omitempty"`
+	InsecureSkipVerify bool   `json:"insecure_skip_verify,omitempty"`
+	CAFile             string `json:"ca_file,omitempty"`
+	CertFile           string `json:"cert_file,omitempty"`
+	KeyFile            string `json:"key_file,omitempty"`
+	ServerName         string `json:"server_name,omitempty"`
+}
+
+// JetStreamConfig contains JetStream-level configuration defaults.
+type JetStreamConfig struct {
+	Domain         string        `json:"domain,omitempty"`
+	APIPrefix      string        `json:"api_prefix,omitempty"`
+	DefaultTimeout time.Duration `json:"default_timeout,omitempty"`
+}
+
+// SubjectConfig defines the subject patterns used by the shared contract.
+type SubjectConfig struct {
+	ConfigurePattern string `json:"configure_pattern"`
+	ActionPattern    string `json:"action_pattern"`
+	ResultPattern    string `json:"result_pattern"`
+	StatusPattern    string `json:"status_pattern"`
+	HealthPattern    string `json:"health_pattern"`
+}
+
+// KVConfig defines desired-configuration storage settings.
+type KVConfig struct {
+	Bucket           string        `json:"bucket"`
+	KeyPattern       string        `json:"key_pattern"`
+	AutoCreateBucket bool          `json:"auto_create_bucket,omitempty"`
+	History          uint8         `json:"history,omitempty"`
+	TTL              time.Duration `json:"ttl,omitempty"`
+	MaxValueSize     int32         `json:"max_value_size,omitempty"`
+	Storage          string        `json:"storage,omitempty"`
+	Replicas         int           `json:"replicas,omitempty"`
+}
+
+// TimeoutConfig groups public timeout values used by networked operations.
+type TimeoutConfig struct {
+	PublishTimeout   time.Duration `json:"publish_timeout,omitempty"`
+	SubscribeTimeout time.Duration `json:"subscribe_timeout,omitempty"`
+	KVTimeout        time.Duration `json:"kv_timeout,omitempty"`
+	ShutdownTimeout  time.Duration `json:"shutdown_timeout,omitempty"`
+	HandlerWarnAfter time.Duration `json:"handler_warn_after,omitempty"`
+}
+
+// RetryConfig defines retry policy knobs for public operations.
+type RetryConfig struct {
+	PublishAttempts int           `json:"publish_attempts,omitempty"`
+	PublishBackoff  time.Duration `json:"publish_backoff,omitempty"`
+}
+
+// ExecutionConfig describes handler execution mode without exposing internals.
+type ExecutionConfig struct {
+	HandlerMode string `json:"handler_mode,omitempty"`
+}
+
+// ObserveConfig allows optional observability hooks to be supplied at config time.
+type ObserveConfig struct {
+	Logger  Logger  `json:"-"`
+	Metrics Metrics `json:"-"`
+}

--- a/agentcore/contracts.go
+++ b/agentcore/contracts.go
@@ -77,10 +77,13 @@ type ResultEnvelope struct {
 }
 
 // StatusEnvelope reports target-owned status updates.
+// UUID is optional for generic status, but should be provided for configure
+// progress/status so consumers can correlate to desired-config identity.
 type StatusEnvelope struct {
 	Version   string          `json:"version"`
 	RPCID     string          `json:"rpc_id,omitempty"`
 	Target    string          `json:"target"`
+	UUID      string          `json:"uuid,omitempty"`
 	Status    string          `json:"status"`
 	Stage     string          `json:"stage,omitempty"`
 	Message   string          `json:"message,omitempty"`

--- a/agentcore/contracts.go
+++ b/agentcore/contracts.go
@@ -6,6 +6,7 @@ import (
 )
 
 // BaseEnvelope contains common fields used across the shared wire contract.
+// RPCID is used for request/response correlation across transport flows.
 type BaseEnvelope struct {
 	Version   string    `json:"version"`
 	RPCID     string    `json:"rpc_id,omitempty"`
@@ -14,6 +15,7 @@ type BaseEnvelope struct {
 }
 
 // ConfigureCommand is the caller-facing configure submission payload.
+// UUID is the opaque desired-config identity used for sync/apply decisions.
 type ConfigureCommand struct {
 	Version   string          `json:"version"`
 	RPCID     string          `json:"rpc_id"`
@@ -24,6 +26,7 @@ type ConfigureCommand struct {
 }
 
 // DesiredConfigRecord is the authoritative desired state stored in KV.
+// UUID is the opaque desired-config identity used for sync/apply decisions.
 type DesiredConfigRecord struct {
 	Version   string          `json:"version"`
 	RPCID     string          `json:"rpc_id"`
@@ -34,6 +37,8 @@ type DesiredConfigRecord struct {
 }
 
 // ConfigureNotification is the lightweight post-store configure trigger.
+// RPCID is used for correlation, while UUID is the desired-config identity
+// agents compare against locally applied state.
 type ConfigureNotification struct {
 	Version     string    `json:"version"`
 	RPCID       string    `json:"rpc_id"`
@@ -42,7 +47,6 @@ type ConfigureNotification struct {
 	UUID        string    `json:"uuid"`
 	KVBucket    string    `json:"kv_bucket"`
 	KVKey       string    `json:"kv_key"`
-	KVRevision  uint64    `json:"kv_revision"`
 	Timestamp   time.Time `json:"timestamp"`
 }
 
@@ -85,6 +89,8 @@ type StatusEnvelope struct {
 }
 
 // StoredDesiredConfig represents a desired-config record loaded from KV.
+// Revision is KV storage metadata only and is intended for diagnostics and
+// storage introspection, not desired-state version semantics.
 type StoredDesiredConfig struct {
 	Record    DesiredConfigRecord `json:"record"`
 	Bucket    string              `json:"bucket"`
@@ -94,6 +100,8 @@ type StoredDesiredConfig struct {
 }
 
 // SubmissionAck reports acceptance of a configure or action submission.
+// KVRevision is write metadata only and does not determine agent sync or apply
+// correctness.
 type SubmissionAck struct {
 	Accepted   bool      `json:"accepted"`
 	RPCID      string    `json:"rpc_id,omitempty"`

--- a/agentcore/contracts.go
+++ b/agentcore/contracts.go
@@ -1,0 +1,137 @@
+package agentcore
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// BaseEnvelope contains common fields used across the shared wire contract.
+type BaseEnvelope struct {
+	Version   string    `json:"version"`
+	RPCID     string    `json:"rpc_id,omitempty"`
+	Target    string    `json:"target"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// ConfigureCommand is the caller-facing configure submission payload.
+type ConfigureCommand struct {
+	Version   string          `json:"version"`
+	RPCID     string          `json:"rpc_id"`
+	Target    string          `json:"target"`
+	UUID      string          `json:"uuid"`
+	Payload   json.RawMessage `json:"payload"`
+	Timestamp time.Time       `json:"timestamp"`
+}
+
+// DesiredConfigRecord is the authoritative desired state stored in KV.
+type DesiredConfigRecord struct {
+	Version   string          `json:"version"`
+	RPCID     string          `json:"rpc_id"`
+	Target    string          `json:"target"`
+	UUID      string          `json:"uuid"`
+	Payload   json.RawMessage `json:"payload"`
+	Timestamp time.Time       `json:"timestamp"`
+}
+
+// ConfigureNotification is the lightweight post-store configure trigger.
+type ConfigureNotification struct {
+	Version     string    `json:"version"`
+	RPCID       string    `json:"rpc_id"`
+	Target      string    `json:"target"`
+	CommandType string    `json:"command_type"`
+	UUID        string    `json:"uuid"`
+	KVBucket    string    `json:"kv_bucket"`
+	KVKey       string    `json:"kv_key"`
+	KVRevision  uint64    `json:"kv_revision"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// ActionCommand is the transient action request published on Core NATS.
+type ActionCommand struct {
+	Version     string          `json:"version"`
+	RPCID       string          `json:"rpc_id"`
+	Target      string          `json:"target"`
+	CommandType string          `json:"command_type"`
+	Action      string          `json:"action"`
+	Payload     json.RawMessage `json:"payload"`
+	Timestamp   time.Time       `json:"timestamp"`
+}
+
+// ResultEnvelope reports the outcome of configure or action processing.
+type ResultEnvelope struct {
+	Version     string          `json:"version"`
+	RPCID       string          `json:"rpc_id"`
+	Target      string          `json:"target"`
+	CommandType string          `json:"command_type,omitempty"`
+	UUID        string          `json:"uuid,omitempty"`
+	Action      string          `json:"action,omitempty"`
+	Result      string          `json:"result"`
+	Message     string          `json:"message,omitempty"`
+	ErrorCode   string          `json:"error_code,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+	Timestamp   time.Time       `json:"timestamp"`
+}
+
+// StatusEnvelope reports target-owned status updates.
+type StatusEnvelope struct {
+	Version   string          `json:"version"`
+	RPCID     string          `json:"rpc_id,omitempty"`
+	Target    string          `json:"target"`
+	Status    string          `json:"status"`
+	Stage     string          `json:"stage,omitempty"`
+	Message   string          `json:"message,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	Timestamp time.Time       `json:"timestamp"`
+}
+
+// StoredDesiredConfig represents a desired-config record loaded from KV.
+type StoredDesiredConfig struct {
+	Record    DesiredConfigRecord `json:"record"`
+	Bucket    string              `json:"bucket"`
+	Key       string              `json:"key"`
+	Revision  uint64              `json:"revision"`
+	CreatedAt time.Time           `json:"created_at"`
+}
+
+// SubmissionAck reports acceptance of a configure or action submission.
+type SubmissionAck struct {
+	Accepted   bool      `json:"accepted"`
+	RPCID      string    `json:"rpc_id,omitempty"`
+	Target     string    `json:"target,omitempty"`
+	Subject    string    `json:"subject,omitempty"`
+	AcceptedAt time.Time `json:"accepted_at,omitempty"`
+	KVBucket   string    `json:"kv_bucket,omitempty"`
+	KVKey      string    `json:"kv_key,omitempty"`
+	KVRevision uint64    `json:"kv_revision,omitempty"`
+}
+
+// ConnectionState is the public state model exposed by HealthSnapshot.
+type ConnectionState string
+
+const (
+	// StateNew indicates a client has been created but not started.
+	StateNew ConnectionState = "new"
+	// StateConnecting indicates the client is attempting initial connect.
+	StateConnecting ConnectionState = "connecting"
+	// StateConnected indicates the client is connected and usable.
+	StateConnected ConnectionState = "connected"
+	// StateReconnecting indicates the transport is recovering from a disconnect.
+	StateReconnecting ConnectionState = "reconnecting"
+	// StateDraining indicates graceful shutdown is in progress.
+	StateDraining ConnectionState = "draining"
+	// StateClosed indicates the client is fully closed.
+	StateClosed ConnectionState = "closed"
+	// StateDegraded indicates the client is reachable but not fully healthy.
+	StateDegraded ConnectionState = "degraded"
+)
+
+// HealthSnapshot exposes a read-only view of client connection health.
+type HealthSnapshot struct {
+	State                   ConnectionState `json:"state"`
+	ConnectedURL            string          `json:"connected_url,omitempty"`
+	JetStreamReady          bool            `json:"jetstream_ready"`
+	KVReady                 bool            `json:"kv_ready"`
+	RegisteredSubscriptions int             `json:"registered_subscriptions"`
+	ActiveSubscriptions     int             `json:"active_subscriptions"`
+	LastError               string          `json:"last_error,omitempty"`
+}

--- a/agentcore/contracts_test.go
+++ b/agentcore/contracts_test.go
@@ -204,6 +204,7 @@ func TestStatusEnvelopeJSONRoundTrip(t *testing.T) {
 		Version:   "1.0",
 		RPCID:     "rpc-status-1",
 		Target:    "vyos",
+		UUID:      "cfg-001",
 		Status:    "running",
 		Stage:     "startup",
 		Message:   "agent ready",
@@ -229,6 +230,9 @@ func TestStatusEnvelopeJSONRoundTrip(t *testing.T) {
 	}
 	if got.Target != want.Target {
 		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
 	}
 	if got.Status != want.Status {
 		t.Fatalf("expected Status %q, got %q", want.Status, got.Status)

--- a/agentcore/contracts_test.go
+++ b/agentcore/contracts_test.go
@@ -1,0 +1,323 @@
+package agentcore
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func contractTestTime() time.Time {
+	return time.Unix(1700000000, 0).UTC()
+}
+
+/*
+TC-CONTRACT-001
+Type: Positive
+Title: ConfigureCommand survives JSON round-trip
+Summary:
+Verifies basic JSON sanity for the public configure submission model.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - key public fields survive round-trip intact
+*/
+func TestConfigureCommandJSONRoundTrip(t *testing.T) {
+	want := ConfigureCommand{
+		Version:   "1.0",
+		RPCID:     "rpc-config-1",
+		Target:    "vyos",
+		UUID:      "cfg-001",
+		Payload:   json.RawMessage(`{"hostname":"router-1"}`),
+		Timestamp: contractTestTime(),
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got ConfigureCommand
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.Version != want.Version {
+		t.Fatalf("expected Version %q, got %q", want.Version, got.Version)
+	}
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.Target != want.Target {
+		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Fatalf("expected Timestamp %v, got %v", want.Timestamp, got.Timestamp)
+	}
+}
+
+/*
+TC-CONTRACT-002
+Type: Positive
+Title: ActionCommand survives JSON round-trip
+Summary:
+Verifies basic JSON sanity for the public action submission model.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - command metadata and payload survive round-trip intact
+*/
+func TestActionCommandJSONRoundTrip(t *testing.T) {
+	want := ActionCommand{
+		Version:     "1.0",
+		RPCID:       "rpc-action-1",
+		Target:      "vyos",
+		CommandType: "action",
+		Action:      "trace",
+		Payload:     json.RawMessage(`{"destination":"8.8.8.8"}`),
+		Timestamp:   contractTestTime(),
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got ActionCommand
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.Version != want.Version {
+		t.Fatalf("expected Version %q, got %q", want.Version, got.Version)
+	}
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.Target != want.Target {
+		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.CommandType != want.CommandType {
+		t.Fatalf("expected CommandType %q, got %q", want.CommandType, got.CommandType)
+	}
+	if got.Action != want.Action {
+		t.Fatalf("expected Action %q, got %q", want.Action, got.Action)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Fatalf("expected Timestamp %v, got %v", want.Timestamp, got.Timestamp)
+	}
+}
+
+/*
+TC-CONTRACT-003
+Type: Positive
+Title: ResultEnvelope survives JSON round-trip
+Summary:
+Verifies basic JSON sanity for the public result model.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - result correlation fields survive round-trip intact
+*/
+func TestResultEnvelopeJSONRoundTrip(t *testing.T) {
+	want := ResultEnvelope{
+		Version:     "1.0",
+		RPCID:       "rpc-result-1",
+		Target:      "vyos",
+		CommandType: "configure",
+		UUID:        "cfg-001",
+		Action:      "trace",
+		Result:      "success",
+		Message:     "applied",
+		ErrorCode:   "",
+		Payload:     json.RawMessage(`{"applied":true}`),
+		Timestamp:   contractTestTime(),
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got ResultEnvelope
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.Version != want.Version {
+		t.Fatalf("expected Version %q, got %q", want.Version, got.Version)
+	}
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.Target != want.Target {
+		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.CommandType != want.CommandType {
+		t.Fatalf("expected CommandType %q, got %q", want.CommandType, got.CommandType)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+	if got.Action != want.Action {
+		t.Fatalf("expected Action %q, got %q", want.Action, got.Action)
+	}
+	if got.Result != want.Result {
+		t.Fatalf("expected Result %q, got %q", want.Result, got.Result)
+	}
+	if got.Message != want.Message {
+		t.Fatalf("expected Message %q, got %q", want.Message, got.Message)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Fatalf("expected Timestamp %v, got %v", want.Timestamp, got.Timestamp)
+	}
+}
+
+/*
+TC-CONTRACT-004
+Type: Positive
+Title: StatusEnvelope survives JSON round-trip
+Summary:
+Verifies basic JSON sanity for the public status model.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - status fields and payload survive round-trip intact
+*/
+func TestStatusEnvelopeJSONRoundTrip(t *testing.T) {
+	want := StatusEnvelope{
+		Version:   "1.0",
+		RPCID:     "rpc-status-1",
+		Target:    "vyos",
+		Status:    "running",
+		Stage:     "startup",
+		Message:   "agent ready",
+		Payload:   json.RawMessage(`{"ready":true}`),
+		Timestamp: contractTestTime(),
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got StatusEnvelope
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.Version != want.Version {
+		t.Fatalf("expected Version %q, got %q", want.Version, got.Version)
+	}
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.Target != want.Target {
+		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.Status != want.Status {
+		t.Fatalf("expected Status %q, got %q", want.Status, got.Status)
+	}
+	if got.Stage != want.Stage {
+		t.Fatalf("expected Stage %q, got %q", want.Stage, got.Stage)
+	}
+	if got.Message != want.Message {
+		t.Fatalf("expected Message %q, got %q", want.Message, got.Message)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Fatalf("expected Timestamp %v, got %v", want.Timestamp, got.Timestamp)
+	}
+}
+
+/*
+TC-CONTRACT-005
+Type: Positive
+Title: HealthSnapshot survives JSON round-trip
+Summary:
+Verifies basic JSON sanity for the public read-only health model.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - state and health counters survive round-trip intact
+*/
+func TestHealthSnapshotJSONRoundTrip(t *testing.T) {
+	want := HealthSnapshot{
+		State:                   StateConnected,
+		ConnectedURL:            "nats://localhost:4222",
+		JetStreamReady:          true,
+		KVReady:                 true,
+		RegisteredSubscriptions: 3,
+		ActiveSubscriptions:     2,
+		LastError:               "none",
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got HealthSnapshot
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.State != want.State {
+		t.Fatalf("expected State %q, got %q", want.State, got.State)
+	}
+	if got.ConnectedURL != want.ConnectedURL {
+		t.Fatalf("expected ConnectedURL %q, got %q", want.ConnectedURL, got.ConnectedURL)
+	}
+	if got.JetStreamReady != want.JetStreamReady {
+		t.Fatalf("expected JetStreamReady %v, got %v", want.JetStreamReady, got.JetStreamReady)
+	}
+	if got.KVReady != want.KVReady {
+		t.Fatalf("expected KVReady %v, got %v", want.KVReady, got.KVReady)
+	}
+	if got.RegisteredSubscriptions != want.RegisteredSubscriptions {
+		t.Fatalf("expected RegisteredSubscriptions %d, got %d", want.RegisteredSubscriptions, got.RegisteredSubscriptions)
+	}
+	if got.ActiveSubscriptions != want.ActiveSubscriptions {
+		t.Fatalf("expected ActiveSubscriptions %d, got %d", want.ActiveSubscriptions, got.ActiveSubscriptions)
+	}
+	if got.LastError != want.LastError {
+		t.Fatalf("expected LastError %q, got %q", want.LastError, got.LastError)
+	}
+}
+
+/*
+TC-CONTRACT-006
+Type: Negative
+Title: ConfigureCommand unmarshal rejects malformed JSON
+Summary:
+Verifies that invalid JSON input is rejected by the standard public model decoder.
+
+Validates:
+  - malformed JSON returns a non-nil unmarshal error
+*/
+func TestConfigureCommandUnmarshalRejectsMalformedJSON(t *testing.T) {
+	data := []byte(`{"version":"1.0","rpc_id":"rpc-1","target":"vyos",`)
+
+	var got ConfigureCommand
+	if err := json.Unmarshal(data, &got); err == nil {
+		t.Fatal("expected unmarshal error for malformed JSON, got nil")
+	}
+}

--- a/agentcore/contracts_test.go
+++ b/agentcore/contracts_test.go
@@ -325,3 +325,265 @@ func TestConfigureCommandUnmarshalRejectsMalformedJSON(t *testing.T) {
 		t.Fatal("expected unmarshal error for malformed JSON, got nil")
 	}
 }
+
+/*
+TC-CONTRACT-007
+Type: Positive
+Title: DesiredConfigRecord survives JSON round-trip
+Summary:
+Verifies basic JSON sanity for the public desired configuration storage model.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - config identity and payload survive round-trip intact
+*/
+func TestDesiredConfigRecordJSONRoundTrip(t *testing.T) {
+	want := DesiredConfigRecord{
+		Version:   "1.0",
+		Target:    "vyos",
+		UUID:      "cfg-002",
+		Payload:   json.RawMessage(`{"interfaces":[{"name":"eth0"}]}`),
+		Timestamp: contractTestTime(),
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got DesiredConfigRecord
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.Version != want.Version {
+		t.Fatalf("expected Version %q, got %q", want.Version, got.Version)
+	}
+	if got.Target != want.Target {
+		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Fatalf("expected Timestamp %v, got %v", want.Timestamp, got.Timestamp)
+	}
+}
+
+/*
+TC-CONTRACT-008
+Type: Positive
+Title: ConfigureNotification survives JSON round-trip
+Summary:
+Verifies basic JSON sanity for the lightweight configure notification model.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - notification correlation fields survive round-trip intact
+*/
+func TestConfigureNotificationJSONRoundTrip(t *testing.T) {
+	want := ConfigureNotification{
+		Version:   "1.0",
+		RPCID:     "rpc-config-2",
+		Target:    "vyos",
+		UUID:      "cfg-002",
+		Timestamp: contractTestTime(),
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got ConfigureNotification
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.Version != want.Version {
+		t.Fatalf("expected Version %q, got %q", want.Version, got.Version)
+	}
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.Target != want.Target {
+		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Fatalf("expected Timestamp %v, got %v", want.Timestamp, got.Timestamp)
+	}
+}
+
+/*
+TC-CONTRACT-009
+Type: Positive
+Title: StoredDesiredConfig survives JSON round-trip
+Summary:
+Verifies basic JSON sanity for the public stored desired configuration model.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - revision metadata and desired config record survive round-trip intact
+*/
+func TestStoredDesiredConfigJSONRoundTrip(t *testing.T) {
+	want := StoredDesiredConfig{
+		Revision:  7,
+		CreatedAt: contractTestTime(),
+		Record: DesiredConfigRecord{
+			Version:   "1.0",
+			Target:    "vyos",
+			UUID:      "cfg-003",
+			Payload:   json.RawMessage(`{"system":{"host-name":"edge-1"}}`),
+			Timestamp: contractTestTime(),
+		},
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got StoredDesiredConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.Revision != want.Revision {
+		t.Fatalf("expected Revision %d, got %d", want.Revision, got.Revision)
+	}
+	if !got.CreatedAt.Equal(want.CreatedAt) {
+		t.Fatalf("expected CreatedAt %v, got %v", want.CreatedAt, got.CreatedAt)
+	}
+	if got.Record.Version != want.Record.Version {
+		t.Fatalf("expected Record.Version %q, got %q", want.Record.Version, got.Record.Version)
+	}
+	if got.Record.Target != want.Record.Target {
+		t.Fatalf("expected Record.Target %q, got %q", want.Record.Target, got.Record.Target)
+	}
+	if got.Record.UUID != want.Record.UUID {
+		t.Fatalf("expected Record.UUID %q, got %q", want.Record.UUID, got.Record.UUID)
+	}
+	if string(got.Record.Payload) != string(want.Record.Payload) {
+		t.Fatalf("expected Record.Payload %s, got %s", string(want.Record.Payload), string(got.Record.Payload))
+	}
+	if !got.Record.Timestamp.Equal(want.Record.Timestamp) {
+		t.Fatalf("expected Record.Timestamp %v, got %v", want.Record.Timestamp, got.Record.Timestamp)
+	}
+}
+
+/*
+TC-CONTRACT-010
+Type: Negative
+Title: ConfigureCommand unmarshal rejects wrong timestamp type
+Summary:
+Verifies that structurally valid JSON with the wrong timestamp type is rejected
+by the public configure command model.
+
+Validates:
+  - unmarshal returns a non-nil error for invalid timestamp type
+*/
+func TestConfigureCommandUnmarshalRejectsWrongTimestampType(t *testing.T) {
+	data := []byte(`{
+		"version":"1.0",
+		"rpc_id":"rpc-config-3",
+		"target":"vyos",
+		"uuid":"cfg-004",
+		"payload":{"hostname":"router-2"},
+		"timestamp":123
+	}`)
+
+	var got ConfigureCommand
+	if err := json.Unmarshal(data, &got); err == nil {
+		t.Fatal("expected unmarshal error for wrong timestamp type, got nil")
+	}
+}
+
+/*
+TC-CONTRACT-011
+Type: Positive
+Title: SubmissionAck survives full JSON round-trip
+Summary:
+Verifies basic JSON sanity for the public SubmissionAck model when all major
+fields are populated.
+
+Validates:
+  - marshal succeeds
+  - unmarshal succeeds
+  - accepted flag and metadata fields survive round-trip
+*/
+func TestSubmissionAckJSONRoundTripFull(t *testing.T) {
+	want := SubmissionAck{
+		Accepted:   true,
+		RPCID:      "rpc-ack-1",
+		Target:     "vyos",
+		Subject:    "cmd.configure.vyos",
+		AcceptedAt: contractTestTime(),
+		KVBucket:   "cfg_desired",
+		KVKey:      "desired.vyos",
+		KVRevision: 7,
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got SubmissionAck
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.Accepted != want.Accepted {
+		t.Fatalf("expected Accepted %v, got %v", want.Accepted, got.Accepted)
+	}
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.Target != want.Target {
+		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.Subject != want.Subject {
+		t.Fatalf("expected Subject %q, got %q", want.Subject, got.Subject)
+	}
+	if !got.AcceptedAt.Equal(want.AcceptedAt) {
+		t.Fatalf("expected AcceptedAt %v, got %v", want.AcceptedAt, got.AcceptedAt)
+	}
+	if got.KVBucket != want.KVBucket {
+		t.Fatalf("expected KVBucket %q, got %q", want.KVBucket, got.KVBucket)
+	}
+	if got.KVKey != want.KVKey {
+		t.Fatalf("expected KVKey %q, got %q", want.KVKey, got.KVKey)
+	}
+	if got.KVRevision != want.KVRevision {
+		t.Fatalf("expected KVRevision %d, got %d", want.KVRevision, got.KVRevision)
+	}
+}
+
+/*
+TC-CONTRACT-012
+Type: Negative
+Title: SubmissionAck unmarshal rejects wrong accepted type
+Summary:
+Verifies that invalid JSON field types are rejected for the Accepted field in
+the public SubmissionAck model.
+
+Validates:
+  - wrong accepted type returns unmarshal error
+*/
+func TestSubmissionAckUnmarshalRejectsWrongAcceptedType(t *testing.T) {
+	data := []byte(`{"accepted":"yes"}`)
+
+	var got SubmissionAck
+	if err := json.Unmarshal(data, &got); err == nil {
+		t.Fatal("expected unmarshal error for wrong accepted type, got nil")
+	}
+}

--- a/agentcore/doc.go
+++ b/agentcore/doc.go
@@ -1,0 +1,4 @@
+// Package agentcore provides the reusable shared bus-facing library used by
+// long-running agents. It standardizes the public NATS, JetStream, KV, and wire
+// contract API without turning the library itself into a daemon.
+package agentcore

--- a/agentcore/errors.go
+++ b/agentcore/errors.go
@@ -1,0 +1,82 @@
+package agentcore
+
+import "fmt"
+
+// Code identifies a machine-readable public failure category.
+type Code string
+
+const (
+	// CodeValidation indicates a transport-level validation failure.
+	CodeValidation Code = "validation"
+	// CodeConnectionFailed indicates connection setup failed.
+	CodeConnectionFailed Code = "connection_failed"
+	// CodeDisconnected indicates an operation was attempted while disconnected.
+	CodeDisconnected Code = "disconnected"
+	// CodeJetStreamFailed indicates JetStream setup or usage failed.
+	CodeJetStreamFailed Code = "jetstream_failed"
+	// CodeKVStoreFailed indicates writing desired config to KV failed.
+	CodeKVStoreFailed Code = "kv_store_failed"
+	// CodeKVReadFailed indicates reading desired config from KV failed.
+	CodeKVReadFailed Code = "kv_read_failed"
+	// CodeConfigNotFound indicates desired config was not found.
+	CodeConfigNotFound Code = "config_not_found"
+	// CodePublishFailed indicates a publish operation failed.
+	CodePublishFailed Code = "publish_failed"
+	// CodeSubscribeFailed indicates a subscribe operation failed.
+	CodeSubscribeFailed Code = "subscribe_failed"
+	// CodeDecodeFailed indicates message decoding failed.
+	CodeDecodeFailed Code = "decode_failed"
+	// CodeEncodeFailed indicates message encoding failed.
+	CodeEncodeFailed Code = "encode_failed"
+	// CodeRegistryConflict indicates a subscription registration conflict.
+	CodeRegistryConflict Code = "registry_conflict"
+	// CodeShutdown indicates a shutdown-related failure.
+	CodeShutdown Code = "shutdown"
+	// CodeNotImplemented is used temporarily for bootstrap stubs.
+	CodeNotImplemented Code = "not_implemented"
+)
+
+// Error is the typed public error model used by the library facade.
+type Error struct {
+	Code      Code   `json:"code"`
+	Op        string `json:"op,omitempty"`
+	Subject   string `json:"subject,omitempty"`
+	Key       string `json:"key,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Retryable bool   `json:"retryable"`
+	Err       error  `json:"-"`
+}
+
+// Error satisfies the error interface.
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Op == "" && e.Message == "" {
+		return string(e.Code)
+	}
+	if e.Op == "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	}
+	if e.Message == "" {
+		return fmt.Sprintf("%s: %s", e.Op, e.Code)
+	}
+	return fmt.Sprintf("%s: %s (%s)", e.Op, e.Message, e.Code)
+}
+
+// Unwrap exposes the underlying cause when present.
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// Wrap creates a typed Error around an underlying cause.
+func Wrap(code Code, op string, err error) *Error {
+	return &Error{
+		Code: code,
+		Op:   op,
+		Err:  err,
+	}
+}

--- a/agentcore/errors_test.go
+++ b/agentcore/errors_test.go
@@ -175,3 +175,29 @@ func TestUnwrapOnNilReceiverReturnsNil(t *testing.T) {
 		t.Fatalf("expected nil, got %v", got)
 	}
 }
+
+/*
+TC-ERROR-008
+Type: Positive
+Title: Error string includes op and code when message is empty
+Summary:
+Verifies the Error.Error() formatting branch where Op is set but Message is
+empty. In this case, the string should still be stable and meaningful.
+
+Validates:
+  - Error() returns "<op>: <code>" when Message is empty
+  - formatting does not require Message to be populated
+*/
+func TestErrorStringReturnsOpAndCodeWhenMessageIsEmpty(t *testing.T) {
+	err := &Error{
+		Code: CodeDecodeFailed,
+		Op:   "decode_result",
+	}
+
+	got := err.Error()
+	want := "decode_result: decode_failed"
+
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/agentcore/errors_test.go
+++ b/agentcore/errors_test.go
@@ -1,0 +1,177 @@
+package agentcore
+
+import (
+	"errors"
+	"testing"
+)
+
+/*
+TC-ERROR-001
+Type: Positive
+Title: Error string returns code when only code is set
+Summary:
+Verifies the minimal string representation for a typed error that only carries
+a machine-readable code.
+
+Validates:
+  - Error() returns the code string when Op and Message are empty
+*/
+func TestErrorStringReturnsCodeWhenOnlyCodeIsSet(t *testing.T) {
+	err := &Error{Code: CodeNotImplemented}
+
+	got := err.Error()
+	want := "not_implemented"
+
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+/*
+TC-ERROR-002
+Type: Positive
+Title: Error string includes code and message when op is absent
+Summary:
+Verifies the public error formatting branch where only Code and Message are
+present.
+
+Validates:
+  - Error() returns "<code>: <message>" when Op is empty
+*/
+func TestErrorStringReturnsCodeAndMessageWhenOpIsAbsent(t *testing.T) {
+	err := &Error{
+		Code:    CodeValidation,
+		Message: "clock function is nil",
+	}
+
+	got := err.Error()
+	want := "validation: clock function is nil"
+
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+/*
+TC-ERROR-003
+Type: Positive
+Title: Error string includes op, message, and code when all are present
+Summary:
+Verifies the richest error formatting branch used by typed public API failures.
+
+Validates:
+  - Error() returns "<op>: <message> (<code>)" when all fields are set
+*/
+func TestErrorStringReturnsOpMessageAndCodeWhenAllFieldsAreSet(t *testing.T) {
+	err := &Error{
+		Code:    CodePublishFailed,
+		Op:      "publish_status",
+		Message: "publish failed",
+	}
+
+	got := err.Error()
+	want := "publish_status: publish failed (publish_failed)"
+
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+/*
+TC-ERROR-004
+Type: Negative
+Title: Nil typed error returns stable placeholder string
+Summary:
+Verifies nil receiver safety for the Error() method.
+
+Validates:
+  - calling Error() on a nil *Error does not panic
+  - returned value is the defined placeholder string
+*/
+func TestErrorStringOnNilReceiverReturnsPlaceholder(t *testing.T) {
+	var err *Error
+
+	got := err.Error()
+	want := "<nil>"
+
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+/*
+TC-ERROR-005
+Type: Positive
+Title: Unwrap exposes the underlying cause
+Summary:
+Verifies that the typed public error integrates with Go's standard error
+wrapping behavior.
+
+Validates:
+  - Unwrap() returns the underlying cause
+  - errors.Is(...) works through the typed wrapper
+*/
+func TestUnwrapExposesUnderlyingCause(t *testing.T) {
+	cause := errors.New("root cause")
+	err := &Error{
+		Code: CodeDecodeFailed,
+		Op:   "decode_result",
+		Err:  cause,
+	}
+
+	if got := err.Unwrap(); got != cause {
+		t.Fatalf("expected cause %v, got %v", cause, got)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatal("expected errors.Is to match wrapped cause")
+	}
+}
+
+/*
+TC-ERROR-006
+Type: Positive
+Title: Wrap creates a typed error around a cause
+Summary:
+Verifies the helper constructor used to build typed errors around underlying
+Go errors.
+
+Validates:
+  - Wrap(...) stores code, op, and cause
+  - returned value is non-nil
+*/
+func TestWrapCreatesTypedError(t *testing.T) {
+	cause := errors.New("decode failed")
+
+	err := Wrap(CodeDecodeFailed, "decode_result", cause)
+	if err == nil {
+		t.Fatal("expected non-nil wrapped error")
+	}
+	if err.Code != CodeDecodeFailed {
+		t.Fatalf("expected code %q, got %q", CodeDecodeFailed, err.Code)
+	}
+	if err.Op != "decode_result" {
+		t.Fatalf("expected op %q, got %q", "decode_result", err.Op)
+	}
+	if err.Err != cause {
+		t.Fatalf("expected cause %v, got %v", cause, err.Err)
+	}
+}
+
+/*
+TC-ERROR-007
+Type: Negative
+Title: Nil typed error unwrap is safe
+Summary:
+Verifies nil receiver safety for Unwrap().
+
+Validates:
+  - calling Unwrap() on a nil *Error does not panic
+  - returned cause is nil
+*/
+func TestUnwrapOnNilReceiverReturnsNil(t *testing.T) {
+	var err *Error
+
+	if got := err.Unwrap(); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}

--- a/agentcore/observe.go
+++ b/agentcore/observe.go
@@ -1,0 +1,21 @@
+package agentcore
+
+import "time"
+
+// Logger is the caller-provided structured logging hook.
+type Logger interface {
+	Debug(msg string, kv ...any)
+	Info(msg string, kv ...any)
+	Warn(msg string, kv ...any)
+	Error(msg string, kv ...any)
+}
+
+// Metrics is the caller-provided observability hook defined by the LLD.
+type Metrics interface {
+	IncConnect(result string)
+	SetConnectionState(state string)
+	IncPublish(kind, subject, result string)
+	ObservePublishLatency(kind, subject string, d time.Duration)
+	IncSubscribe(kind, subject, result string)
+	IncKV(op, result string)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module nats-agent-core
+module github.com/routerarchitects/nats-agent-core
 
 go 1.23.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module nats-agent-core
+
+go 1.23.0


### PR DESCRIPTION
## Summary
This PR adds the Phase 1 bootstrap for `nats-agent-core`.

It introduces the initial public library surface and supporting Phase 1 test/documentation scaffolding:

- module bootstrap with `go.mod`
- public config model
- public client facade and lifecycle/method signatures
- shared message and storage contract models
- typed public error model
- logger and metrics interfaces
- package-level bootstrap files under `agentcore/`
- initial Phase 1 unit tests
- CI workflow for running tests
- prompt/spec/checklist files used for this phase

## What is included
- `go.mod`
- `.github/workflows/ci.yml`
- `README.md`
- `SPEC.md`
- `REQUIREMENTS_CHECKLIST.md`
- `PROMPTS/IMPLEMENTATION_PROMPT.md`
- `PROMPTS/01-bootstrap.md`
- `PROMPTS/01b-api-corrections.md`
- `agentcore/client.go`
- `agentcore/client_test.go`
- `agentcore/config.go`
- `agentcore/contracts.go`
- `agentcore/contracts_test.go`
- `agentcore/doc.go`
- `agentcore/errors.go`
- `agentcore/errors_test.go`
- `agentcore/observe.go`

## What is intentionally not included
This PR does not implement:

- NATS connection/session lifecycle
- JetStream context creation
- KV storage operations
- subject builders/validation
- publish/subscribe logic
- subscription registry/reconnect restore
- examples
- integration/runtime transport behavior

## Why
The goal of this phase is to lock the public API and shared contract shape before implementing transport/runtime behavior in later phases.

This PR now also adds initial Phase 1 unit coverage for the bootstrap behavior that already exists, without introducing later-phase runtime assumptions.

## Validation
- `go test ./...` passes
- initial Phase 1 unit tests are included for:
  - client bootstrap behavior
  - typed errors
  - public contract JSON/model sanity
- CI is configured to run the Go test suite on the PR

## Related issue
Closes routerarchitects/TIP-olg-nats-agent-core#3 