### PR TITLE
feat(contract): add shared contract validation and JSON codec

### DIFF
--- a/PROMPTS/02-contract-models.md
+++ b/PROMPTS/02-contract-models.md
@@ -1,0 +1,69 @@
+Read PROMPTS/IMPLEMENTATION_PROMPT.md carefully.
+Also read SPEC.md for additional design context.
+Use PROMPTS/IMPLEMENTATION_PROMPT.md as the primary implementation source of truth for code generation scope, API shape, and wire-contract behavior.
+
+Also read REQUIREMENTS_CHECKLIST.md and the current codebase carefully.
+
+Build on the already-corrected Phase 1 public API under agentcore/.
+Treat the current public types and method signatures as the baseline unless a minimal compatibility correction is absolutely required.
+
+Now implement only:
+1. internal/contract
+2. transport-level validation for the public envelopes/models
+3. centralized JSON encode/decode helpers for the standard wire envelopes
+
+Requirements to focus on:
+- NATS-LIB-08
+- NATS-LIB-09
+- NATS-LIB-10
+- NATS-LIB-14
+
+Goal:
+Add the shared contract layer that enforces the wire format and shared envelope sanity checks, while keeping validation strictly transport-level and workload-agnostic.
+
+Rules:
+- Keep validation limited to shared transport/wire sanity checks only
+- Do not add cloud/business-policy validation
+- Do not add workload-specific validation
+- Do not implement subjects/routing yet
+- Do not implement session/NATS connection/JetStream/KV yet
+- Do not implement submission flows, handlers, registry, or reconnect logic yet
+- Do not add tests in this phase
+- Keep payloads as json.RawMessage where the public API defines them that way
+- Keep codec logic centralized, small, and reusable
+- Keep code modular, testable, and race-safe
+- Do not invent extra domain-specific fields not present in the implementation prompt or corrected public API
+
+Validation expectations:
+- Validate only required transport-level fields and shared envelope correctness
+- Preserve rpc_id, target, uuid/config UUID, action, timestamp, and version semantics from PROMPTS/IMPLEMENTATION_PROMPT.md
+- Reject malformed or missing required identifiers where the wire contract requires them
+- Do not treat UUID as an ordering field, version sequence, or freshness indicator
+- Do not introduce historical config retrieval or revision-ordered behavior
+- Do not embed business meaning into validation beyond shared contract sanity
+
+Suggested files:
+- internal/contract/codec.go
+- internal/contract/validate.go
+- internal/contract/helpers.go
+
+Add more small focused files only if clearly needed.
+
+After coding:
+- summarize exactly which files were added or changed
+- explain how the implementation aligns with PROMPTS/IMPLEMENTATION_PROMPT.md
+- map each added/changed file to the relevant requirement IDs from REQUIREMENTS_CHECKLIST.md, especially:
+  - NATS-LIB-08
+  - NATS-LIB-09
+  - NATS-LIB-10
+  - NATS-LIB-14
+- list any minimal public API adjustments made, if any
+- list what is intentionally deferred to later phases
+
+Review checklist for this phase:
+- validation is not too smart
+- only transport-level checks are implemented
+- rpc_id, target, uuid, and action are preserved properly
+- codec logic is centralized
+- no session/KV/subjects/transport behavior leaked into this phase
+- no workload/business logic was added

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ deferred to later phases.
 The intended end-state of this library is to help agents:
 
 This section describes the target design and is not fully implemented in the
-current Phase 1 bootstrap.
+current Phase 1 + Phase 2 state.
 
 - connect to NATS
 - reconnect after temporary disconnects

--- a/README.md
+++ b/README.md
@@ -34,17 +34,20 @@ In simple words:
 
 ## Current status
 
-This repository is currently at **Phase 1 bootstrap**.
+This repository is currently at **Phase 1 bootstrap + Phase 2 contract layer**.
 
-The current code defines the public API surface and shared message contract only:
+Current code includes:
 - public config types
 - public client method signatures
 - standard envelope and storage models
 - typed public errors
 - logger and metrics interfaces
+- shared contract codec helpers (`internal/contract`)
+- shared contract validation helpers (`internal/contract`)
 
-Runtime behavior is intentionally **not implemented yet** in this phase.
-That means transport/session/KV/subject/publish-subscribe/reconnect logic is
+Runtime transport behavior is intentionally **not implemented yet** in this
+phase set. That means transport/session/KV/subject/publish-subscribe/reconnect
+runtime execution logic is
 deferred to later phases.
 
 ---
@@ -100,7 +103,7 @@ The library is designed around the idea that agents use shared transport/state h
 ## Basic communication model
 
 The flows below describe the target design. They are not fully implemented in
-the current Phase 1 bootstrap.
+the current Phase 1 + Phase 2 state.
 
 ### Configure flow
 
@@ -153,3 +156,4 @@ The library uses KV to hold the current desired configuration for a target.
 ## Notes
 
 For the normative design contract and exact behavior, see `SPEC.md`.
+SubmitConfigure failure semantics are defined in `SPEC.md` section `6.4`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -122,6 +122,16 @@ The configure notification is a trigger telling the target agent to reload desir
 
 The notification is **not** the full desired configuration payload.
 
+Configure notification required fields are:
+- `version`
+- `rpc_id`
+- `target`
+- `command_type`
+- `uuid`
+- `kv_bucket`
+- `kv_key`
+- `timestamp`
+
 ### 6.3 Configure result contract
 
 Configure result/status messages must include:
@@ -134,24 +144,38 @@ This is required so the cloud-facing side can determine:
 
 `rpc_id` alone is not sufficient for configure outcomes.
 
-### 6.4 Configure submission failure semantics
+### 6.4 SubmitConfigure failure semantics
 
-SubmissionAck is a direct API return value from configure submission calls.
-It is not a bus-delivered message and is not published or consumed over NATS subjects.
+`SubmitConfigure(...)` succeeds only when both steps complete successfully:
+1. desired config is written to KV
+2. configure notification is published
 
-Configure submission must expose clear failure outcomes:
+When either step fails, the call returns a submission error and does not return a successful `SubmissionAck`.
+`SubmissionAck` is a direct API return value from `SubmitConfigure(...)`, not a bus-delivered message.
 
-- validation failure:
-  - submission is rejected
-  - desired config is not written to KV
-  - configure notification is not published
-- KV store failure:
-  - submission fails
-  - configure notification is not published
-- notify publish failure after KV store success:
-  - submission fails with explicit publish-failure semantics
-  - desired config remains stored in KV (no implicit rollback)
-  - callers may retry notification or re-submit based on policy
+The following cases define caller-visible behavior:
+
+- Validation failure
+  Missing or invalid required fields.
+  Operational result: no KV write, no notification publish, returns submission error.
+
+- KV store failure
+  Desired config could not be persisted.
+  Operational result: no successful `SubmissionAck`, no notification publish, returns submission error.
+
+- Notification publish failure after KV write success
+  Desired config was already written to KV, but notification publish failed.
+  Operational result: returns submission error with no successful `SubmissionAck`; desired state may already have changed in KV.
+
+- Context timeout or cancellation
+  Context ended before submission completed.
+  Operational result: returns submission error. Side effects depend on how far execution progressed before context end:
+  if cancellation happened before KV write, no state change; if cancellation happened after KV write, desired state may already be updated even when the call returns error.
+
+Caller guidance:
+- Treat `SubmissionAck` as transport acceptance only, not apply success.
+- Treat apply success as confirmed only by result/status from the owning target agent.
+- For retries after error, assume partial side effects are possible and use config UUID comparison to determine current desired state.
 
 ---
 

--- a/internal/contract/codec.go
+++ b/internal/contract/codec.go
@@ -1,0 +1,185 @@
+package contract
+
+import (
+	"encoding/json"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+func encodeJSON(op string, value any) ([]byte, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, encodeError(op, err)
+	}
+	return encoded, nil
+}
+
+func decodeJSON(op string, data []byte, out any) error {
+	if len(data) == 0 {
+		return validationError(op, "payload is required")
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return decodeError(op, err)
+	}
+	return nil
+}
+
+// EncodeConfigureCommand validates and encodes a ConfigureCommand.
+func EncodeConfigureCommand(msg agentcore.ConfigureCommand) ([]byte, error) {
+	if err := ValidateConfigureCommand(msg); err != nil {
+		return nil, err
+	}
+	return encodeJSON("encode_configure_command", msg)
+}
+
+// DecodeConfigureCommand decodes and validates a ConfigureCommand.
+func DecodeConfigureCommand(data []byte) (agentcore.ConfigureCommand, error) {
+	var msg agentcore.ConfigureCommand
+	if err := decodeJSON("decode_configure_command", data, &msg); err != nil {
+		return agentcore.ConfigureCommand{}, err
+	}
+	if err := ValidateConfigureCommand(msg); err != nil {
+		return agentcore.ConfigureCommand{}, err
+	}
+	return msg, nil
+}
+
+// EncodeDesiredConfigRecord validates and encodes a DesiredConfigRecord.
+func EncodeDesiredConfigRecord(msg agentcore.DesiredConfigRecord) ([]byte, error) {
+	if err := ValidateDesiredConfigRecord(msg); err != nil {
+		return nil, err
+	}
+	return encodeJSON("encode_desired_config_record", msg)
+}
+
+// DecodeDesiredConfigRecord decodes and validates a DesiredConfigRecord.
+func DecodeDesiredConfigRecord(data []byte) (agentcore.DesiredConfigRecord, error) {
+	var msg agentcore.DesiredConfigRecord
+	if err := decodeJSON("decode_desired_config_record", data, &msg); err != nil {
+		return agentcore.DesiredConfigRecord{}, err
+	}
+	if err := ValidateDesiredConfigRecord(msg); err != nil {
+		return agentcore.DesiredConfigRecord{}, err
+	}
+	return msg, nil
+}
+
+// EncodeConfigureNotification validates and encodes a ConfigureNotification.
+func EncodeConfigureNotification(msg agentcore.ConfigureNotification) ([]byte, error) {
+	if err := ValidateConfigureNotification(msg); err != nil {
+		return nil, err
+	}
+	return encodeJSON("encode_configure_notification", msg)
+}
+
+// DecodeConfigureNotification decodes and validates a ConfigureNotification.
+func DecodeConfigureNotification(data []byte) (agentcore.ConfigureNotification, error) {
+	var msg agentcore.ConfigureNotification
+	if err := decodeJSON("decode_configure_notification", data, &msg); err != nil {
+		return agentcore.ConfigureNotification{}, err
+	}
+	if err := ValidateConfigureNotification(msg); err != nil {
+		return agentcore.ConfigureNotification{}, err
+	}
+	return msg, nil
+}
+
+// EncodeActionCommand validates and encodes an ActionCommand.
+func EncodeActionCommand(msg agentcore.ActionCommand) ([]byte, error) {
+	if err := ValidateActionCommand(msg); err != nil {
+		return nil, err
+	}
+	return encodeJSON("encode_action_command", msg)
+}
+
+// DecodeActionCommand decodes and validates an ActionCommand.
+func DecodeActionCommand(data []byte) (agentcore.ActionCommand, error) {
+	var msg agentcore.ActionCommand
+	if err := decodeJSON("decode_action_command", data, &msg); err != nil {
+		return agentcore.ActionCommand{}, err
+	}
+	if err := ValidateActionCommand(msg); err != nil {
+		return agentcore.ActionCommand{}, err
+	}
+	return msg, nil
+}
+
+// EncodeResultEnvelope validates and encodes a ResultEnvelope.
+func EncodeResultEnvelope(msg agentcore.ResultEnvelope) ([]byte, error) {
+	if err := ValidateResultEnvelope(msg); err != nil {
+		return nil, err
+	}
+	return encodeJSON("encode_result_envelope", msg)
+}
+
+// DecodeResultEnvelope decodes and validates a ResultEnvelope.
+func DecodeResultEnvelope(data []byte) (agentcore.ResultEnvelope, error) {
+	var msg agentcore.ResultEnvelope
+	if err := decodeJSON("decode_result_envelope", data, &msg); err != nil {
+		return agentcore.ResultEnvelope{}, err
+	}
+	if err := ValidateResultEnvelope(msg); err != nil {
+		return agentcore.ResultEnvelope{}, err
+	}
+	return msg, nil
+}
+
+// EncodeConfigureResultEnvelope validates and encodes a configure result.
+func EncodeConfigureResultEnvelope(msg agentcore.ResultEnvelope) ([]byte, error) {
+	if err := ValidateConfigureResultEnvelope(msg); err != nil {
+		return nil, err
+	}
+	return encodeJSON("encode_configure_result_envelope", msg)
+}
+
+// DecodeConfigureResultEnvelope decodes and validates a configure result.
+func DecodeConfigureResultEnvelope(data []byte) (agentcore.ResultEnvelope, error) {
+	var msg agentcore.ResultEnvelope
+	if err := decodeJSON("decode_configure_result_envelope", data, &msg); err != nil {
+		return agentcore.ResultEnvelope{}, err
+	}
+	if err := ValidateConfigureResultEnvelope(msg); err != nil {
+		return agentcore.ResultEnvelope{}, err
+	}
+	return msg, nil
+}
+
+// EncodeStatusEnvelope validates and encodes a StatusEnvelope.
+func EncodeStatusEnvelope(msg agentcore.StatusEnvelope) ([]byte, error) {
+	if err := ValidateStatusEnvelope(msg); err != nil {
+		return nil, err
+	}
+	return encodeJSON("encode_status_envelope", msg)
+}
+
+// DecodeStatusEnvelope decodes and validates a StatusEnvelope.
+func DecodeStatusEnvelope(data []byte) (agentcore.StatusEnvelope, error) {
+	var msg agentcore.StatusEnvelope
+	if err := decodeJSON("decode_status_envelope", data, &msg); err != nil {
+		return agentcore.StatusEnvelope{}, err
+	}
+	if err := ValidateStatusEnvelope(msg); err != nil {
+		return agentcore.StatusEnvelope{}, err
+	}
+	return msg, nil
+}
+
+// EncodeConfigureStatusEnvelope validates and encodes a configure status update.
+func EncodeConfigureStatusEnvelope(msg agentcore.StatusEnvelope) ([]byte, error) {
+	if err := ValidateConfigureStatusEnvelope(msg); err != nil {
+		return nil, err
+	}
+	return encodeJSON("encode_configure_status_envelope", msg)
+}
+
+// DecodeConfigureStatusEnvelope decodes and validates a configure status update.
+func DecodeConfigureStatusEnvelope(data []byte) (agentcore.StatusEnvelope, error) {
+	var msg agentcore.StatusEnvelope
+	if err := decodeJSON("decode_configure_status_envelope", data, &msg); err != nil {
+		return agentcore.StatusEnvelope{}, err
+	}
+	if err := ValidateConfigureStatusEnvelope(msg); err != nil {
+		return agentcore.StatusEnvelope{}, err
+	}
+	return msg, nil
+}

--- a/internal/contract/codec_test.go
+++ b/internal/contract/codec_test.go
@@ -1,0 +1,513 @@
+package contract
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+/*
+TC-CONTRACT-CODEC-001
+Type: Positive
+Title: Encode and decode ConfigureCommand round-trips successfully
+Summary:
+Verifies that the configure command codec validates, encodes, decodes, and
+preserves the important wire fields and payload.
+
+Validates:
+  - encode succeeds for a valid configure command
+  - decode succeeds for the encoded payload
+  - payload and identifiers are preserved
+*/
+func TestEncodeDecodeConfigureCommandRoundTrip(t *testing.T) {
+	want := validConfigureCommand()
+
+	encoded, err := EncodeConfigureCommand(want)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	got, err := DecodeConfigureCommand(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.Version != want.Version {
+		t.Fatalf("expected Version %q, got %q", want.Version, got.Version)
+	}
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.Target != want.Target {
+		t.Fatalf("expected Target %q, got %q", want.Target, got.Target)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+	if !got.Timestamp.Equal(want.Timestamp) {
+		t.Fatalf("expected Timestamp %v, got %v", want.Timestamp, got.Timestamp)
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-002
+Type: Negative
+Title: EncodeConfigureCommand rejects semantically invalid command
+Summary:
+Verifies that configure command encoding performs validation first and rejects
+invalid commands instead of producing JSON.
+
+Validates:
+  - invalid configure command returns CodeValidation
+  - validator op is preserved
+*/
+func TestEncodeConfigureCommandRejectsInvalidCommand(t *testing.T) {
+	msg := validConfigureCommand()
+	msg.UUID = ""
+
+	_, err := EncodeConfigureCommand(msg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", "uuid is required")
+}
+
+/*
+TC-CONTRACT-CODEC-003
+Type: Negative
+Title: DecodeConfigureCommand rejects empty payload
+Summary:
+Verifies that configure command decoding rejects missing raw input before JSON
+unmarshal is attempted.
+
+Validates:
+  - empty payload returns CodeValidation
+  - decode op is preserved
+*/
+func TestDecodeConfigureCommandRejectsEmptyPayload(t *testing.T) {
+	_, err := DecodeConfigureCommand(nil)
+
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "decode_configure_command", "payload is required")
+}
+
+/*
+TC-CONTRACT-CODEC-004
+Type: Negative
+Title: DecodeConfigureCommand rejects malformed JSON
+Summary:
+Verifies that configure command decoding wraps malformed JSON errors as typed
+decode failures.
+
+Validates:
+  - malformed JSON returns CodeDecodeFailed
+  - wrapped low-level JSON error is preserved
+*/
+func TestDecodeConfigureCommandRejectsMalformedJSON(t *testing.T) {
+	_, err := DecodeConfigureCommand([]byte(`{"version":"1.0","rpc_id":"rpc-1",`))
+
+	got := requireAgentcoreError(t, err, agentcore.CodeDecodeFailed, "decode_configure_command", "failed to decode JSON payload")
+	if got.Unwrap() == nil {
+		t.Fatal("expected wrapped decode cause to be preserved")
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-005
+Type: Negative
+Title: DecodeConfigureCommand rejects decoded command that fails validation
+Summary:
+Verifies that configure command decoding performs validation after successful
+JSON unmarshal and rejects invalid decoded content.
+
+Validates:
+  - decoded message missing uuid returns CodeValidation
+  - validator op is configure-command specific
+*/
+func TestDecodeConfigureCommandRejectsSemanticallyInvalidDecodedCommand(t *testing.T) {
+	data := []byte(`{
+		"version":"1.0",
+		"rpc_id":"rpc-config-1",
+		"target":"vyos",
+		"uuid":"",
+		"payload":{"hostname":"router-1"},
+		"timestamp":"2023-11-14T22:13:20Z"
+	}`)
+
+	_, err := DecodeConfigureCommand(data)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", "uuid is required")
+}
+
+/*
+TC-CONTRACT-CODEC-006
+Type: Positive
+Title: Encode and decode DesiredConfigRecord round-trips successfully
+Summary:
+Verifies that desired-config record codec preserves record identifiers and raw
+payload across encode/decode operations.
+
+Validates:
+  - encode succeeds
+  - decode succeeds
+  - payload and identifiers are preserved
+*/
+func TestEncodeDecodeDesiredConfigRecordRoundTrip(t *testing.T) {
+	want := validDesiredConfigRecord()
+
+	encoded, err := EncodeDesiredConfigRecord(want)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	got, err := DecodeDesiredConfigRecord(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.RPCID != want.RPCID || got.UUID != want.UUID || got.Target != want.Target {
+		t.Fatalf("expected identifiers %+v, got %+v", want, got)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-007
+Type: Positive
+Title: Encode and decode ConfigureNotification round-trips successfully
+Summary:
+Verifies that configure notification codec preserves the notification contract
+fields used for configure signaling.
+
+Validates:
+  - encode succeeds
+  - decode succeeds
+  - kv_bucket kv_key rpc_id and uuid are preserved
+*/
+func TestEncodeDecodeConfigureNotificationRoundTrip(t *testing.T) {
+	want := validConfigureNotification()
+
+	encoded, err := EncodeConfigureNotification(want)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	got, err := DecodeConfigureNotification(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+	if got.KVBucket != want.KVBucket {
+		t.Fatalf("expected KVBucket %q, got %q", want.KVBucket, got.KVBucket)
+	}
+	if got.KVKey != want.KVKey {
+		t.Fatalf("expected KVKey %q, got %q", want.KVKey, got.KVKey)
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-008
+Type: Positive
+Title: Encode and decode ActionCommand round-trips successfully
+Summary:
+Verifies that action command codec preserves action-specific identifiers and
+payload across encode/decode.
+
+Validates:
+  - encode succeeds
+  - decode succeeds
+  - action and payload are preserved
+*/
+func TestEncodeDecodeActionCommandRoundTrip(t *testing.T) {
+	want := validActionCommand()
+
+	encoded, err := EncodeActionCommand(want)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	got, err := DecodeActionCommand(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.Action != want.Action {
+		t.Fatalf("expected Action %q, got %q", want.Action, got.Action)
+	}
+	if got.CommandType != want.CommandType {
+		t.Fatalf("expected CommandType %q, got %q", want.CommandType, got.CommandType)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-009
+Type: Negative
+Title: DecodeActionCommand rejects malformed JSON
+Summary:
+Verifies that malformed action JSON returns a typed decode failure.
+
+Validates:
+  - malformed JSON returns CodeDecodeFailed
+  - wrapped cause is preserved
+*/
+func TestDecodeActionCommandRejectsMalformedJSON(t *testing.T) {
+	_, err := DecodeActionCommand([]byte(`{"version":"1.0","rpc_id":"rpc-1",`))
+
+	got := requireAgentcoreError(t, err, agentcore.CodeDecodeFailed, "decode_action_command", "failed to decode JSON payload")
+	if got.Unwrap() == nil {
+		t.Fatal("expected wrapped decode cause to be preserved")
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-010
+Type: Positive
+Title: Encode and decode ResultEnvelope round-trips successfully
+Summary:
+Verifies that generic result codec preserves result identity fields and payload.
+
+Validates:
+  - encode succeeds
+  - decode succeeds
+  - result payload is preserved
+*/
+func TestEncodeDecodeResultEnvelopeRoundTrip(t *testing.T) {
+	want := validResultEnvelope()
+
+	encoded, err := EncodeResultEnvelope(want)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	got, err := DecodeResultEnvelope(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.Result != want.Result {
+		t.Fatalf("expected Result %q, got %q", want.Result, got.Result)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-011
+Type: Positive
+Title: Encode and decode configure result round-trips successfully
+Summary:
+Verifies that configure-specific result codec preserves the stricter configure
+result semantics, including required uuid.
+
+Validates:
+  - encode succeeds
+  - decode succeeds
+  - required configure uuid is preserved
+*/
+func TestEncodeDecodeConfigureResultEnvelopeRoundTrip(t *testing.T) {
+	want := validResultEnvelope()
+
+	encoded, err := EncodeConfigureResultEnvelope(want)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	got, err := DecodeConfigureResultEnvelope(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-012
+Type: Negative
+Title: EncodeConfigureResultEnvelope rejects missing uuid
+Summary:
+Verifies that configure-specific result encoding enforces required configure
+uuid semantics before JSON is produced.
+
+Validates:
+  - missing uuid returns CodeValidation
+  - configure-result validator op is preserved
+*/
+func TestEncodeConfigureResultEnvelopeRejectsMissingUUID(t *testing.T) {
+	msg := validResultEnvelope()
+	msg.UUID = ""
+
+	_, err := EncodeConfigureResultEnvelope(msg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_result_envelope", "uuid is required")
+}
+
+/*
+TC-CONTRACT-CODEC-013
+Type: Positive
+Title: Encode and decode StatusEnvelope round-trips successfully
+Summary:
+Verifies that generic status codec preserves status fields and the Phase 2
+optional uuid addition.
+
+Validates:
+  - encode succeeds
+  - decode succeeds
+  - uuid and payload are preserved
+*/
+func TestEncodeDecodeStatusEnvelopeRoundTrip(t *testing.T) {
+	want := validStatusEnvelope()
+
+	encoded, err := EncodeStatusEnvelope(want)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	got, err := DecodeStatusEnvelope(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+	if got.Status != want.Status {
+		t.Fatalf("expected Status %q, got %q", want.Status, got.Status)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		t.Fatalf("expected Payload %s, got %s", string(want.Payload), string(got.Payload))
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-014
+Type: Negative
+Title: DecodeStatusEnvelope rejects empty payload
+Summary:
+Verifies that generic status decoding rejects missing raw input before decode.
+
+Validates:
+  - empty raw input returns CodeValidation
+  - decode op is preserved
+*/
+func TestDecodeStatusEnvelopeRejectsEmptyPayload(t *testing.T) {
+	_, err := DecodeStatusEnvelope(nil)
+
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "decode_status_envelope", "payload is required")
+}
+
+/*
+TC-CONTRACT-CODEC-015
+Type: Positive
+Title: Encode and decode configure status round-trips successfully
+Summary:
+Verifies that configure-specific status codec preserves configure rpc_id and
+uuid semantics across encode/decode.
+
+Validates:
+  - encode succeeds
+  - decode succeeds
+  - rpc_id and uuid are preserved
+*/
+func TestEncodeDecodeConfigureStatusEnvelopeRoundTrip(t *testing.T) {
+	want := validStatusEnvelope()
+
+	encoded, err := EncodeConfigureStatusEnvelope(want)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	got, err := DecodeConfigureStatusEnvelope(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.RPCID != want.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", want.RPCID, got.RPCID)
+	}
+	if got.UUID != want.UUID {
+		t.Fatalf("expected UUID %q, got %q", want.UUID, got.UUID)
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-016
+Type: Negative
+Title: EncodeConfigureStatusEnvelope rejects missing rpc_id or uuid
+Summary:
+Verifies that configure-specific status encoding enforces required configure
+status identifiers before JSON is produced.
+
+Validates:
+  - missing rpc_id returns CodeValidation
+  - missing uuid returns CodeValidation
+*/
+func TestEncodeConfigureStatusEnvelopeRejectsMissingRPCIDOrUUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*agentcore.StatusEnvelope)
+		msgPart string
+	}{
+		{
+			name: "missing rpc_id",
+			mutate: func(msg *agentcore.StatusEnvelope) {
+				msg.RPCID = ""
+			},
+			msgPart: "rpc_id is required",
+		},
+		{
+			name: "missing uuid",
+			mutate: func(msg *agentcore.StatusEnvelope) {
+				msg.UUID = ""
+			},
+			msgPart: "uuid is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validStatusEnvelope()
+			tc.mutate(&msg)
+
+			_, err := EncodeConfigureStatusEnvelope(msg)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_status_envelope", tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-CONTRACT-CODEC-017
+Type: Negative
+Title: Decode helper preserves wrapped cause for malformed JSON
+Summary:
+Verifies that malformed decode paths expose an underlying cause through the
+typed error wrapper.
+
+Validates:
+  - errors.As reaches *agentcore.Error
+  - errors.Is can reach the wrapped cause when present
+*/
+func TestDecodeMalformedJSONPreservesWrappedCause(t *testing.T) {
+	_, err := DecodeResultEnvelope([]byte(`{"version":"1.0",`))
+	got := requireAgentcoreError(t, err, agentcore.CodeDecodeFailed, "decode_result_envelope", "failed to decode JSON payload")
+	if got.Unwrap() == nil {
+		t.Fatal("expected wrapped decode cause to be preserved")
+	}
+	if !errors.Is(got, got.Unwrap()) {
+		t.Fatal("expected errors.Is to match wrapped decode cause")
+	}
+}

--- a/internal/contract/helpers.go
+++ b/internal/contract/helpers.go
@@ -1,0 +1,82 @@
+package contract
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+func validationError(op, msg string) error {
+	return &agentcore.Error{
+		Code:      agentcore.CodeValidation,
+		Op:        op,
+		Message:   msg,
+		Retryable: false,
+	}
+}
+
+func decodeError(op string, err error) error {
+	return &agentcore.Error{
+		Code:      agentcore.CodeDecodeFailed,
+		Op:        op,
+		Message:   "failed to decode JSON payload",
+		Retryable: false,
+		Err:       err,
+	}
+}
+
+func encodeError(op string, err error) error {
+	return &agentcore.Error{
+		Code:      agentcore.CodeEncodeFailed,
+		Op:        op,
+		Message:   "failed to encode JSON payload",
+		Retryable: false,
+		Err:       err,
+	}
+}
+
+func requiredString(op, field, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return validationError(op, field+" is required")
+	}
+	return nil
+}
+
+func optionalString(op, field, value string) error {
+	if value == "" {
+		return nil
+	}
+	if strings.TrimSpace(value) == "" {
+		return validationError(op, field+" cannot be whitespace")
+	}
+	return nil
+}
+
+func requiredTimestamp(op, field string, value time.Time) error {
+	if value.IsZero() {
+		return validationError(op, field+" is required")
+	}
+	return nil
+}
+
+func requiredJSON(op, field string, payload json.RawMessage) error {
+	if len(payload) == 0 {
+		return validationError(op, field+" is required")
+	}
+	if !json.Valid(payload) {
+		return validationError(op, field+" must contain valid JSON")
+	}
+	return nil
+}
+
+func optionalJSON(op, field string, payload json.RawMessage) error {
+	if len(payload) == 0 {
+		return nil
+	}
+	if !json.Valid(payload) {
+		return validationError(op, field+" must contain valid JSON")
+	}
+	return nil
+}

--- a/internal/contract/helpers_test.go
+++ b/internal/contract/helpers_test.go
@@ -1,0 +1,392 @@
+package contract
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+func contractTestTime() time.Time {
+	return time.Unix(1700000000, 0).UTC()
+}
+
+func rawJSON(s string) json.RawMessage {
+	return json.RawMessage(s)
+}
+
+func validBaseEnvelope() agentcore.BaseEnvelope {
+	return agentcore.BaseEnvelope{
+		Version:   "1.0",
+		RPCID:     "rpc-base-1",
+		Target:    "vyos",
+		Timestamp: contractTestTime(),
+	}
+}
+
+func validConfigureCommand() agentcore.ConfigureCommand {
+	return agentcore.ConfigureCommand{
+		Version:   "1.0",
+		RPCID:     "rpc-config-1",
+		Target:    "vyos",
+		UUID:      "cfg-001",
+		Payload:   rawJSON(`{"hostname":"router-1"}`),
+		Timestamp: contractTestTime(),
+	}
+}
+
+func validDesiredConfigRecord() agentcore.DesiredConfigRecord {
+	return agentcore.DesiredConfigRecord{
+		Version:   "1.0",
+		RPCID:     "rpc-record-1",
+		Target:    "vyos",
+		UUID:      "cfg-001",
+		Payload:   rawJSON(`{"interfaces":[]}`),
+		Timestamp: contractTestTime(),
+	}
+}
+
+func validConfigureNotification() agentcore.ConfigureNotification {
+	return agentcore.ConfigureNotification{
+		Version:     "1.0",
+		RPCID:       "rpc-notify-1",
+		Target:      "vyos",
+		CommandType: "configure",
+		UUID:        "cfg-001",
+		KVBucket:    "cfg_desired",
+		KVKey:       "desired.vyos",
+		Timestamp:   contractTestTime(),
+	}
+}
+
+func validActionCommand() agentcore.ActionCommand {
+	return agentcore.ActionCommand{
+		Version:     "1.0",
+		RPCID:       "rpc-action-1",
+		Target:      "vyos",
+		CommandType: "action",
+		Action:      "trace",
+		Payload:     rawJSON(`{"destination":"8.8.8.8"}`),
+		Timestamp:   contractTestTime(),
+	}
+}
+
+func validResultEnvelope() agentcore.ResultEnvelope {
+	return agentcore.ResultEnvelope{
+		Version:     "1.0",
+		RPCID:       "rpc-result-1",
+		Target:      "vyos",
+		CommandType: "configure",
+		UUID:        "cfg-001",
+		Action:      "trace",
+		Result:      "success",
+		Message:     "applied",
+		ErrorCode:   "",
+		Payload:     rawJSON(`{"applied":true}`),
+		Timestamp:   contractTestTime(),
+	}
+}
+
+func validStatusEnvelope() agentcore.StatusEnvelope {
+	return agentcore.StatusEnvelope{
+		Version:   "1.0",
+		RPCID:     "rpc-status-1",
+		Target:    "vyos",
+		UUID:      "cfg-001",
+		Status:    "running",
+		Stage:     "startup",
+		Message:   "agent ready",
+		Payload:   rawJSON(`{"ready":true}`),
+		Timestamp: contractTestTime(),
+	}
+}
+
+func validStoredDesiredConfig() agentcore.StoredDesiredConfig {
+	return agentcore.StoredDesiredConfig{
+		Record:    validDesiredConfigRecord(),
+		Bucket:    "cfg_desired",
+		Key:       "desired.vyos",
+		Revision:  7,
+		CreatedAt: contractTestTime(),
+	}
+}
+
+func requireAgentcoreError(t *testing.T, err error, wantCode agentcore.Code, wantOp string, wantMsgPart string) *agentcore.Error {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+
+	var got *agentcore.Error
+	if !errors.As(err, &got) {
+		t.Fatalf("expected *agentcore.Error, got %T", err)
+	}
+	if got.Code != wantCode {
+		t.Fatalf("expected error code %q, got %q", wantCode, got.Code)
+	}
+	if got.Op != wantOp {
+		t.Fatalf("expected error op %q, got %q", wantOp, got.Op)
+	}
+	if wantMsgPart != "" && !strings.Contains(got.Message, wantMsgPart) {
+		t.Fatalf("expected error message to contain %q, got %q", wantMsgPart, got.Message)
+	}
+	return got
+}
+
+/*
+TC-CONTRACT-HELPERS-001
+Type: Positive
+Title: validationError returns a typed validation error
+Summary:
+Verifies that the shared helper for validation failures produces the expected
+typed public error with validation semantics.
+
+Validates:
+  - returned error is *agentcore.Error
+  - error code is CodeValidation
+  - error op and message are preserved
+*/
+func TestValidationErrorReturnsTypedValidationError(t *testing.T) {
+	err := validationError("validate_configure_command", "rpc_id is required")
+
+	got := requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", "rpc_id is required")
+	if got.Retryable {
+		t.Fatal("expected validation error to be non-retryable")
+	}
+}
+
+/*
+TC-CONTRACT-HELPERS-002
+Type: Positive
+Title: decodeError wraps the underlying decode cause
+Summary:
+Verifies that the shared decode helper returns a typed decode failure while
+preserving the original lower-level cause.
+
+Validates:
+  - returned error is *agentcore.Error
+  - error code is CodeDecodeFailed
+  - underlying cause is preserved
+*/
+func TestDecodeErrorWrapsUnderlyingCause(t *testing.T) {
+	cause := errors.New("unexpected end of JSON input")
+
+	err := decodeError("decode_configure_command", cause)
+
+	got := requireAgentcoreError(t, err, agentcore.CodeDecodeFailed, "decode_configure_command", "failed to decode JSON payload")
+	if !errors.Is(got, cause) {
+		t.Fatal("expected wrapped decode cause to be reachable via errors.Is")
+	}
+}
+
+/*
+TC-CONTRACT-HELPERS-003
+Type: Positive
+Title: encodeError wraps the underlying encode cause
+Summary:
+Verifies that the shared encode helper returns a typed encode failure while
+preserving the original lower-level cause.
+
+Validates:
+  - returned error is *agentcore.Error
+  - error code is CodeEncodeFailed
+  - underlying cause is preserved
+*/
+func TestEncodeErrorWrapsUnderlyingCause(t *testing.T) {
+	cause := errors.New("json: unsupported type")
+
+	err := encodeError("encode_configure_command", cause)
+
+	got := requireAgentcoreError(t, err, agentcore.CodeEncodeFailed, "encode_configure_command", "failed to encode JSON payload")
+	if !errors.Is(got, cause) {
+		t.Fatal("expected wrapped encode cause to be reachable via errors.Is")
+	}
+}
+
+/*
+TC-CONTRACT-HELPERS-004
+Type: Positive
+Title: requiredString accepts a normal non-empty value
+Summary:
+Verifies that required string validation succeeds for a non-empty value.
+
+Validates:
+  - no error is returned for a valid required string
+*/
+func TestRequiredStringAcceptsNonEmptyValue(t *testing.T) {
+	if err := requiredString("validate_configure_command", "target", "vyos"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-HELPERS-005
+Type: Negative
+Title: requiredString rejects whitespace-only values
+Summary:
+Verifies that required string validation trims whitespace and rejects empty or
+whitespace-only values.
+
+Validates:
+  - whitespace-only value returns CodeValidation
+  - error op and message are correct
+*/
+func TestRequiredStringRejectsWhitespaceOnlyValue(t *testing.T) {
+	err := requiredString("validate_configure_command", "target", "   ")
+
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", "target is required")
+}
+
+/*
+TC-CONTRACT-HELPERS-006
+Type: Positive
+Title: optionalString allows an empty optional field
+Summary:
+Verifies that optional string validation permits a truly empty optional field.
+
+Validates:
+  - empty string returns no error
+*/
+func TestOptionalStringAllowsEmptyValue(t *testing.T) {
+	if err := optionalString("validate_status_envelope", "stage", ""); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-HELPERS-007
+Type: Negative
+Title: optionalString rejects whitespace-only optional values
+Summary:
+Verifies that optional string validation distinguishes between empty and
+whitespace-only values.
+
+Validates:
+  - whitespace-only value returns CodeValidation
+  - error message reports cannot be whitespace
+*/
+func TestOptionalStringRejectsWhitespaceOnlyValue(t *testing.T) {
+	err := optionalString("validate_status_envelope", "stage", "   ")
+
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_status_envelope", "stage cannot be whitespace")
+}
+
+/*
+TC-CONTRACT-HELPERS-008
+Type: Positive
+Title: requiredTimestamp accepts a non-zero time
+Summary:
+Verifies that required timestamp validation succeeds for a populated timestamp.
+
+Validates:
+  - non-zero timestamp returns no error
+*/
+func TestRequiredTimestampAcceptsNonZeroValue(t *testing.T) {
+	if err := requiredTimestamp("validate_result_envelope", "timestamp", contractTestTime()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-HELPERS-009
+Type: Negative
+Title: requiredTimestamp rejects zero time
+Summary:
+Verifies that required timestamp validation rejects a zero-value timestamp.
+
+Validates:
+  - zero time returns CodeValidation
+  - error message reports field is required
+*/
+func TestRequiredTimestampRejectsZeroValue(t *testing.T) {
+	err := requiredTimestamp("validate_result_envelope", "timestamp", time.Time{})
+
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_result_envelope", "timestamp is required")
+}
+
+/*
+TC-CONTRACT-HELPERS-010
+Type: Positive
+Title: requiredJSON accepts valid JSON payload
+Summary:
+Verifies that required JSON validation accepts a non-empty valid JSON payload.
+
+Validates:
+  - valid JSON payload returns no error
+*/
+func TestRequiredJSONAcceptsValidPayload(t *testing.T) {
+	if err := requiredJSON("validate_configure_command", "payload", rawJSON(`{"hostname":"router-1"}`)); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-HELPERS-011
+Type: Negative
+Title: requiredJSON rejects empty payload
+Summary:
+Verifies that required JSON validation rejects a missing payload.
+
+Validates:
+  - empty payload returns CodeValidation
+  - error message reports payload is required
+*/
+func TestRequiredJSONRejectsEmptyPayload(t *testing.T) {
+	err := requiredJSON("validate_configure_command", "payload", nil)
+
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", "payload is required")
+}
+
+/*
+TC-CONTRACT-HELPERS-012
+Type: Negative
+Title: requiredJSON rejects invalid JSON payload
+Summary:
+Verifies that required JSON validation rejects syntactically invalid JSON.
+
+Validates:
+  - invalid payload returns CodeValidation
+  - error message reports payload must contain valid JSON
+*/
+func TestRequiredJSONRejectsInvalidPayload(t *testing.T) {
+	err := requiredJSON("validate_configure_command", "payload", rawJSON(`{"hostname":`))
+
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", "payload must contain valid JSON")
+}
+
+/*
+TC-CONTRACT-HELPERS-013
+Type: Positive
+Title: optionalJSON allows empty payload
+Summary:
+Verifies that optional JSON validation permits an omitted optional payload.
+
+Validates:
+  - empty optional payload returns no error
+*/
+func TestOptionalJSONAllowsEmptyPayload(t *testing.T) {
+	if err := optionalJSON("validate_status_envelope", "payload", nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-HELPERS-014
+Type: Negative
+Title: optionalJSON rejects invalid JSON payload
+Summary:
+Verifies that optional JSON validation still rejects malformed JSON when a
+payload is supplied.
+
+Validates:
+  - invalid optional payload returns CodeValidation
+*/
+func TestOptionalJSONRejectsInvalidPayload(t *testing.T) {
+	err := optionalJSON("validate_status_envelope", "payload", rawJSON(`{"ready":`))
+
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_status_envelope", "payload must contain valid JSON")
+}

--- a/internal/contract/validate.go
+++ b/internal/contract/validate.go
@@ -1,0 +1,226 @@
+package contract
+
+import "github.com/routerarchitects/nats-agent-core/agentcore"
+
+// ValidateBaseEnvelope validates shared transport-level envelope fields.
+func ValidateBaseEnvelope(msg agentcore.BaseEnvelope) error {
+	const op = "validate_base_envelope"
+
+	if err := requiredString(op, "version", msg.Version); err != nil {
+		return err
+	}
+	if err := requiredString(op, "target", msg.Target); err != nil {
+		return err
+	}
+	if err := requiredTimestamp(op, "timestamp", msg.Timestamp); err != nil {
+		return err
+	}
+	if err := optionalString(op, "rpc_id", msg.RPCID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateConfigureCommand validates transport-level configure command fields.
+func ValidateConfigureCommand(msg agentcore.ConfigureCommand) error {
+	const op = "validate_configure_command"
+
+	if err := requiredString(op, "version", msg.Version); err != nil {
+		return err
+	}
+	if err := requiredString(op, "rpc_id", msg.RPCID); err != nil {
+		return err
+	}
+	if err := requiredString(op, "target", msg.Target); err != nil {
+		return err
+	}
+	if err := requiredString(op, "uuid", msg.UUID); err != nil {
+		return err
+	}
+	if err := requiredTimestamp(op, "timestamp", msg.Timestamp); err != nil {
+		return err
+	}
+	return requiredJSON(op, "payload", msg.Payload)
+}
+
+// ValidateDesiredConfigRecord validates transport-level desired-config fields.
+func ValidateDesiredConfigRecord(msg agentcore.DesiredConfigRecord) error {
+	const op = "validate_desired_config_record"
+
+	if err := requiredString(op, "version", msg.Version); err != nil {
+		return err
+	}
+	if err := requiredString(op, "rpc_id", msg.RPCID); err != nil {
+		return err
+	}
+	if err := requiredString(op, "target", msg.Target); err != nil {
+		return err
+	}
+	if err := requiredString(op, "uuid", msg.UUID); err != nil {
+		return err
+	}
+	if err := requiredTimestamp(op, "timestamp", msg.Timestamp); err != nil {
+		return err
+	}
+	return requiredJSON(op, "payload", msg.Payload)
+}
+
+// ValidateConfigureNotification validates transport-level configure notification fields.
+func ValidateConfigureNotification(msg agentcore.ConfigureNotification) error {
+	const op = "validate_configure_notification"
+
+	if err := requiredString(op, "version", msg.Version); err != nil {
+		return err
+	}
+	if err := requiredString(op, "rpc_id", msg.RPCID); err != nil {
+		return err
+	}
+	if err := requiredString(op, "target", msg.Target); err != nil {
+		return err
+	}
+	if err := requiredString(op, "command_type", msg.CommandType); err != nil {
+		return err
+	}
+	if err := requiredString(op, "uuid", msg.UUID); err != nil {
+		return err
+	}
+	if err := requiredString(op, "kv_bucket", msg.KVBucket); err != nil {
+		return err
+	}
+	if err := requiredString(op, "kv_key", msg.KVKey); err != nil {
+		return err
+	}
+	return requiredTimestamp(op, "timestamp", msg.Timestamp)
+}
+
+// ValidateActionCommand validates transport-level action command fields.
+func ValidateActionCommand(msg agentcore.ActionCommand) error {
+	const op = "validate_action_command"
+
+	if err := requiredString(op, "version", msg.Version); err != nil {
+		return err
+	}
+	if err := requiredString(op, "rpc_id", msg.RPCID); err != nil {
+		return err
+	}
+	if err := requiredString(op, "target", msg.Target); err != nil {
+		return err
+	}
+	if err := requiredString(op, "command_type", msg.CommandType); err != nil {
+		return err
+	}
+	if err := requiredString(op, "action", msg.Action); err != nil {
+		return err
+	}
+	if err := requiredTimestamp(op, "timestamp", msg.Timestamp); err != nil {
+		return err
+	}
+	return requiredJSON(op, "payload", msg.Payload)
+}
+
+// ValidateResultEnvelope validates transport-level result fields.
+func ValidateResultEnvelope(msg agentcore.ResultEnvelope) error {
+	const op = "validate_result_envelope"
+
+	if err := requiredString(op, "version", msg.Version); err != nil {
+		return err
+	}
+	if err := requiredString(op, "rpc_id", msg.RPCID); err != nil {
+		return err
+	}
+	if err := requiredString(op, "target", msg.Target); err != nil {
+		return err
+	}
+	if err := requiredString(op, "result", msg.Result); err != nil {
+		return err
+	}
+	if err := requiredTimestamp(op, "timestamp", msg.Timestamp); err != nil {
+		return err
+	}
+	if err := optionalString(op, "command_type", msg.CommandType); err != nil {
+		return err
+	}
+	if err := optionalString(op, "uuid", msg.UUID); err != nil {
+		return err
+	}
+	if err := optionalString(op, "action", msg.Action); err != nil {
+		return err
+	}
+	if err := optionalString(op, "error_code", msg.ErrorCode); err != nil {
+		return err
+	}
+	return optionalJSON(op, "payload", msg.Payload)
+}
+
+// ValidateConfigureResultEnvelope validates a configure-flow result.
+func ValidateConfigureResultEnvelope(msg agentcore.ResultEnvelope) error {
+	const op = "validate_configure_result_envelope"
+
+	if err := ValidateResultEnvelope(msg); err != nil {
+		return err
+	}
+	if err := requiredString(op, "uuid", msg.UUID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateStatusEnvelope validates transport-level status fields.
+func ValidateStatusEnvelope(msg agentcore.StatusEnvelope) error {
+	const op = "validate_status_envelope"
+
+	if err := requiredString(op, "version", msg.Version); err != nil {
+		return err
+	}
+	if err := requiredString(op, "target", msg.Target); err != nil {
+		return err
+	}
+	if err := requiredString(op, "status", msg.Status); err != nil {
+		return err
+	}
+	if err := requiredTimestamp(op, "timestamp", msg.Timestamp); err != nil {
+		return err
+	}
+	if err := optionalString(op, "rpc_id", msg.RPCID); err != nil {
+		return err
+	}
+	if err := optionalString(op, "uuid", msg.UUID); err != nil {
+		return err
+	}
+	if err := optionalString(op, "stage", msg.Stage); err != nil {
+		return err
+	}
+	return optionalJSON(op, "payload", msg.Payload)
+}
+
+// ValidateConfigureStatusEnvelope validates a configure-flow status update.
+func ValidateConfigureStatusEnvelope(msg agentcore.StatusEnvelope) error {
+	const op = "validate_configure_status_envelope"
+
+	if err := ValidateStatusEnvelope(msg); err != nil {
+		return err
+	}
+	if err := requiredString(op, "rpc_id", msg.RPCID); err != nil {
+		return err
+	}
+	if err := requiredString(op, "uuid", msg.UUID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateStoredDesiredConfig validates storage-facing desired-config metadata.
+func ValidateStoredDesiredConfig(msg agentcore.StoredDesiredConfig) error {
+	const op = "validate_stored_desired_config"
+
+	if err := ValidateDesiredConfigRecord(msg.Record); err != nil {
+		return err
+	}
+	if err := requiredString(op, "bucket", msg.Bucket); err != nil {
+		return err
+	}
+	if err := requiredString(op, "key", msg.Key); err != nil {
+		return err
+	}
+	return requiredTimestamp(op, "created_at", msg.CreatedAt)
+}

--- a/internal/contract/validate_test.go
+++ b/internal/contract/validate_test.go
@@ -1,0 +1,683 @@
+package contract
+
+import (
+	"testing"
+	"time"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+/*
+TC-CONTRACT-VALIDATE-001
+Type: Positive
+Title: ValidateBaseEnvelope accepts a valid base envelope
+Summary:
+Verifies that shared base envelope validation succeeds when all required
+transport-level fields are present and valid.
+
+Validates:
+  - version is accepted
+  - target is accepted
+  - timestamp is accepted
+  - rpc_id is allowed when non-empty and valid
+*/
+func TestValidateBaseEnvelopeAcceptsValidEnvelope(t *testing.T) {
+	if err := ValidateBaseEnvelope(validBaseEnvelope()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-002
+Type: Negative
+Title: ValidateBaseEnvelope rejects missing required fields
+Summary:
+Verifies that base envelope validation rejects missing required version, target,
+and timestamp values.
+
+Validates:
+  - missing version fails
+  - missing target fails
+  - zero timestamp fails
+*/
+func TestValidateBaseEnvelopeRejectsMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*agentcore.BaseEnvelope)
+		msgPart string
+	}{
+		{
+			name: "missing version",
+			mutate: func(msg *agentcore.BaseEnvelope) {
+				msg.Version = ""
+			},
+			msgPart: "version is required",
+		},
+		{
+			name: "missing target",
+			mutate: func(msg *agentcore.BaseEnvelope) {
+				msg.Target = ""
+			},
+			msgPart: "target is required",
+		},
+		{
+			name: "zero timestamp",
+			mutate: func(msg *agentcore.BaseEnvelope) {
+				msg.Timestamp = time.Time{}
+			},
+			msgPart: "timestamp is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validBaseEnvelope()
+			tc.mutate(&msg)
+
+			err := ValidateBaseEnvelope(msg)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_base_envelope", tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-003
+Type: Negative
+Title: ValidateBaseEnvelope rejects whitespace-only optional rpc_id
+Summary:
+Verifies that rpc_id remains optional on the base envelope, but whitespace-only
+values are rejected as malformed optional input.
+
+Validates:
+  - empty rpc_id is allowed
+  - whitespace-only rpc_id is rejected
+*/
+func TestValidateBaseEnvelopeAllowsEmptyRPCIDButRejectsWhitespaceOnlyRPCID(t *testing.T) {
+	msg := validBaseEnvelope()
+	msg.RPCID = ""
+	if err := ValidateBaseEnvelope(msg); err != nil {
+		t.Fatalf("expected nil error for empty rpc_id, got %v", err)
+	}
+
+	msg.RPCID = "   "
+	err := ValidateBaseEnvelope(msg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_base_envelope", "rpc_id cannot be whitespace")
+}
+
+/*
+TC-CONTRACT-VALIDATE-004
+Type: Positive
+Title: ValidateConfigureCommand accepts a valid configure command
+Summary:
+Verifies that configure command validation succeeds when all required
+transport-level fields and payload are present.
+
+Validates:
+  - required identifiers are accepted
+  - required payload is accepted
+  - timestamp is accepted
+*/
+func TestValidateConfigureCommandAcceptsValidCommand(t *testing.T) {
+	if err := ValidateConfigureCommand(validConfigureCommand()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-005
+Type: Negative
+Title: ValidateConfigureCommand rejects missing required fields
+Summary:
+Verifies that configure command validation rejects missing required version,
+rpc_id, target, uuid, timestamp, and payload fields.
+
+Validates:
+  - missing required strings fail
+  - zero timestamp fails
+  - missing payload fails
+*/
+func TestValidateConfigureCommandRejectsMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*agentcore.ConfigureCommand)
+		msgPart string
+	}{
+		{
+			name: "missing version",
+			mutate: func(msg *agentcore.ConfigureCommand) {
+				msg.Version = ""
+			},
+			msgPart: "version is required",
+		},
+		{
+			name: "missing rpc_id",
+			mutate: func(msg *agentcore.ConfigureCommand) {
+				msg.RPCID = ""
+			},
+			msgPart: "rpc_id is required",
+		},
+		{
+			name: "missing target",
+			mutate: func(msg *agentcore.ConfigureCommand) {
+				msg.Target = ""
+			},
+			msgPart: "target is required",
+		},
+		{
+			name: "missing uuid",
+			mutate: func(msg *agentcore.ConfigureCommand) {
+				msg.UUID = ""
+			},
+			msgPart: "uuid is required",
+		},
+		{
+			name: "zero timestamp",
+			mutate: func(msg *agentcore.ConfigureCommand) {
+				msg.Timestamp = time.Time{}
+			},
+			msgPart: "timestamp is required",
+		},
+		{
+			name: "missing payload",
+			mutate: func(msg *agentcore.ConfigureCommand) {
+				msg.Payload = nil
+			},
+			msgPart: "payload is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validConfigureCommand()
+			tc.mutate(&msg)
+
+			err := ValidateConfigureCommand(msg)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-006
+Type: Negative
+Title: ValidateConfigureCommand rejects invalid payload JSON
+Summary:
+Verifies that configure command validation rejects malformed JSON payloads even
+when all other fields are present.
+
+Validates:
+  - malformed payload returns CodeValidation
+*/
+func TestValidateConfigureCommandRejectsInvalidPayloadJSON(t *testing.T) {
+	msg := validConfigureCommand()
+	msg.Payload = rawJSON(`{"hostname":`)
+
+	err := ValidateConfigureCommand(msg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", "payload must contain valid JSON")
+}
+
+/*
+TC-CONTRACT-VALIDATE-007
+Type: Positive
+Title: ValidateDesiredConfigRecord accepts a valid desired-config record
+Summary:
+Verifies that desired-config record validation succeeds for a valid stored
+desired-state payload.
+
+Validates:
+  - required record identifiers are accepted
+  - payload is accepted
+*/
+func TestValidateDesiredConfigRecordAcceptsValidRecord(t *testing.T) {
+	if err := ValidateDesiredConfigRecord(validDesiredConfigRecord()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-008
+Type: Positive
+Title: ValidateConfigureNotification accepts a valid notification
+Summary:
+Verifies that configure notification validation succeeds for a valid
+post-store notification envelope.
+
+Validates:
+  - command_type is accepted
+  - kv_bucket and kv_key are accepted
+  - rpc_id and uuid are accepted
+*/
+func TestValidateConfigureNotificationAcceptsValidNotification(t *testing.T) {
+	if err := ValidateConfigureNotification(validConfigureNotification()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-009
+Type: Negative
+Title: ValidateConfigureNotification rejects missing notification fields
+Summary:
+Verifies that configure notification validation rejects missing command_type,
+kv_bucket, and kv_key values.
+
+Validates:
+  - missing command_type fails
+  - missing kv_bucket fails
+  - missing kv_key fails
+*/
+func TestValidateConfigureNotificationRejectsMissingFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*agentcore.ConfigureNotification)
+		msgPart string
+	}{
+		{
+			name: "missing command_type",
+			mutate: func(msg *agentcore.ConfigureNotification) {
+				msg.CommandType = ""
+			},
+			msgPart: "command_type is required",
+		},
+		{
+			name: "missing kv_bucket",
+			mutate: func(msg *agentcore.ConfigureNotification) {
+				msg.KVBucket = ""
+			},
+			msgPart: "kv_bucket is required",
+		},
+		{
+			name: "missing kv_key",
+			mutate: func(msg *agentcore.ConfigureNotification) {
+				msg.KVKey = ""
+			},
+			msgPart: "kv_key is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validConfigureNotification()
+			tc.mutate(&msg)
+
+			err := ValidateConfigureNotification(msg)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_notification", tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-010
+Type: Positive
+Title: ValidateActionCommand accepts a valid action command
+Summary:
+Verifies that action command validation succeeds for a valid action wire model.
+
+Validates:
+  - action command required fields are accepted
+  - payload is accepted
+*/
+func TestValidateActionCommandAcceptsValidAction(t *testing.T) {
+	if err := ValidateActionCommand(validActionCommand()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-011
+Type: Negative
+Title: ValidateActionCommand rejects missing required fields
+Summary:
+Verifies that action command validation rejects missing action, command_type,
+and payload fields.
+
+Validates:
+  - missing action fails
+  - missing command_type fails
+  - missing payload fails
+*/
+func TestValidateActionCommandRejectsMissingFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*agentcore.ActionCommand)
+		msgPart string
+	}{
+		{
+			name: "missing action",
+			mutate: func(msg *agentcore.ActionCommand) {
+				msg.Action = ""
+			},
+			msgPart: "action is required",
+		},
+		{
+			name: "missing command_type",
+			mutate: func(msg *agentcore.ActionCommand) {
+				msg.CommandType = ""
+			},
+			msgPart: "command_type is required",
+		},
+		{
+			name: "missing payload",
+			mutate: func(msg *agentcore.ActionCommand) {
+				msg.Payload = nil
+			},
+			msgPart: "payload is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validActionCommand()
+			tc.mutate(&msg)
+
+			err := ValidateActionCommand(msg)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_action_command", tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-012
+Type: Positive
+Title: ValidateResultEnvelope accepts a valid result envelope
+Summary:
+Verifies that generic result validation succeeds when required shared result
+fields are present.
+
+Validates:
+  - version, rpc_id, target, result, and timestamp are accepted
+  - optional payload is accepted when valid
+*/
+func TestValidateResultEnvelopeAcceptsValidResult(t *testing.T) {
+	if err := ValidateResultEnvelope(validResultEnvelope()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-013
+Type: Negative
+Title: ValidateResultEnvelope rejects missing result field
+Summary:
+Verifies that generic result validation rejects a missing required result value.
+
+Validates:
+  - missing result returns CodeValidation
+*/
+func TestValidateResultEnvelopeRejectsMissingResult(t *testing.T) {
+	msg := validResultEnvelope()
+	msg.Result = ""
+
+	err := ValidateResultEnvelope(msg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_result_envelope", "result is required")
+}
+
+/*
+TC-CONTRACT-VALIDATE-014
+Type: Negative
+Title: ValidateResultEnvelope rejects whitespace-only optional fields
+Summary:
+Verifies that optional generic result fields may be empty, but whitespace-only
+values are rejected.
+
+Validates:
+  - empty optional fields are allowed
+  - whitespace-only optional fields are rejected
+*/
+func TestValidateResultEnvelopeOptionalFieldBehavior(t *testing.T) {
+	msg := validResultEnvelope()
+	msg.CommandType = ""
+	msg.UUID = ""
+	msg.Action = ""
+	msg.ErrorCode = ""
+	msg.Payload = nil
+
+	if err := ValidateResultEnvelope(msg); err != nil {
+		t.Fatalf("expected nil error for empty optional fields, got %v", err)
+	}
+
+	msg = validResultEnvelope()
+	msg.CommandType = "   "
+	err := ValidateResultEnvelope(msg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_result_envelope", "command_type cannot be whitespace")
+}
+
+/*
+TC-CONTRACT-VALIDATE-015
+Type: Positive
+Title: ValidateConfigureResultEnvelope accepts configure result with uuid
+Summary:
+Verifies that the configure-specific result validator requires the generic
+result fields and also accepts a configure UUID.
+
+Validates:
+  - generic result validation passes
+  - uuid is required and accepted for configure-flow results
+*/
+func TestValidateConfigureResultEnvelopeAcceptsValidConfigureResult(t *testing.T) {
+	if err := ValidateConfigureResultEnvelope(validResultEnvelope()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-016
+Type: Negative
+Title: ValidateConfigureResultEnvelope requires uuid
+Summary:
+Verifies that configure-flow result validation is stricter than generic result
+validation and requires a uuid.
+
+Validates:
+  - missing uuid returns CodeValidation
+  - validator op is configure-result specific
+*/
+func TestValidateConfigureResultEnvelopeRequiresUUID(t *testing.T) {
+	msg := validResultEnvelope()
+	msg.UUID = ""
+
+	err := ValidateConfigureResultEnvelope(msg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_result_envelope", "uuid is required")
+}
+
+/*
+TC-CONTRACT-VALIDATE-017
+Type: Positive
+Title: ValidateStatusEnvelope accepts a valid status envelope
+Summary:
+Verifies that generic status validation succeeds for a valid status wire model,
+including the new optional uuid field.
+
+Validates:
+  - status required fields are accepted
+  - optional uuid is accepted when valid
+*/
+func TestValidateStatusEnvelopeAcceptsValidStatus(t *testing.T) {
+	if err := ValidateStatusEnvelope(validStatusEnvelope()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-018
+Type: Positive
+Title: ValidateStatusEnvelope allows empty optional rpc_id uuid and stage
+Summary:
+Verifies that generic status validation permits omitted optional fields while
+still validating the required core status fields.
+
+Validates:
+  - empty rpc_id is allowed
+  - empty uuid is allowed
+  - empty stage is allowed
+*/
+func TestValidateStatusEnvelopeAllowsEmptyOptionalFields(t *testing.T) {
+	msg := validStatusEnvelope()
+	msg.RPCID = ""
+	msg.UUID = ""
+	msg.Stage = ""
+	msg.Payload = nil
+
+	if err := ValidateStatusEnvelope(msg); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-019
+Type: Negative
+Title: ValidateStatusEnvelope rejects whitespace-only optional values
+Summary:
+Verifies that generic status validation rejects malformed whitespace-only
+values for optional string fields.
+
+Validates:
+  - whitespace-only uuid is rejected
+  - validator returns CodeValidation
+*/
+func TestValidateStatusEnvelopeRejectsWhitespaceOnlyOptionalValues(t *testing.T) {
+	msg := validStatusEnvelope()
+	msg.UUID = "   "
+
+	err := ValidateStatusEnvelope(msg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_status_envelope", "uuid cannot be whitespace")
+}
+
+/*
+TC-CONTRACT-VALIDATE-020
+Type: Positive
+Title: ValidateConfigureStatusEnvelope accepts configure status with rpc_id and uuid
+Summary:
+Verifies that configure-flow status validation succeeds when both rpc_id and
+uuid are present in addition to the generic status fields.
+
+Validates:
+  - generic status validation passes
+  - rpc_id is required for configure status
+  - uuid is required for configure status
+*/
+func TestValidateConfigureStatusEnvelopeAcceptsValidConfigureStatus(t *testing.T) {
+	if err := ValidateConfigureStatusEnvelope(validStatusEnvelope()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-021
+Type: Negative
+Title: ValidateConfigureStatusEnvelope requires rpc_id and uuid
+Summary:
+Verifies that configure-flow status validation is stricter than generic status
+validation and requires both rpc_id and uuid.
+
+Validates:
+  - missing rpc_id fails
+  - missing uuid fails
+*/
+func TestValidateConfigureStatusEnvelopeRequiresRPCIDAndUUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*agentcore.StatusEnvelope)
+		msgPart string
+	}{
+		{
+			name: "missing rpc_id",
+			mutate: func(msg *agentcore.StatusEnvelope) {
+				msg.RPCID = ""
+			},
+			msgPart: "rpc_id is required",
+		},
+		{
+			name: "missing uuid",
+			mutate: func(msg *agentcore.StatusEnvelope) {
+				msg.UUID = ""
+			},
+			msgPart: "uuid is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validStatusEnvelope()
+			tc.mutate(&msg)
+
+			err := ValidateConfigureStatusEnvelope(msg)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_status_envelope", tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-022
+Type: Positive
+Title: ValidateStoredDesiredConfig accepts valid stored desired config
+Summary:
+Verifies that storage-facing desired config validation succeeds for a valid
+record plus bucket, key, and created_at metadata.
+
+Validates:
+  - nested desired-config record passes
+  - bucket key and created_at are accepted
+*/
+func TestValidateStoredDesiredConfigAcceptsValidStoredConfig(t *testing.T) {
+	if err := ValidateStoredDesiredConfig(validStoredDesiredConfig()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-CONTRACT-VALIDATE-023
+Type: Negative
+Title: ValidateStoredDesiredConfig rejects missing storage metadata
+Summary:
+Verifies that storage-facing desired config validation rejects missing bucket,
+key, and created_at metadata.
+
+Validates:
+  - missing bucket fails
+  - missing key fails
+  - zero created_at fails
+*/
+func TestValidateStoredDesiredConfigRejectsMissingStorageMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*agentcore.StoredDesiredConfig)
+		wantOp  string
+		msgPart string
+	}{
+		{
+			name: "missing bucket",
+			mutate: func(msg *agentcore.StoredDesiredConfig) {
+				msg.Bucket = ""
+			},
+			wantOp:  "validate_stored_desired_config",
+			msgPart: "bucket is required",
+		},
+		{
+			name: "missing key",
+			mutate: func(msg *agentcore.StoredDesiredConfig) {
+				msg.Key = ""
+			},
+			wantOp:  "validate_stored_desired_config",
+			msgPart: "key is required",
+		},
+		{
+			name: "zero created_at",
+			mutate: func(msg *agentcore.StoredDesiredConfig) {
+				msg.CreatedAt = time.Time{}
+			},
+			wantOp:  "validate_stored_desired_config",
+			msgPart: "created_at is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := validStoredDesiredConfig()
+			tc.mutate(&msg)
+
+			err := ValidateStoredDesiredConfig(msg)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, tc.wantOp, tc.msgPart)
+		})
+	}
+}


### PR DESCRIPTION
**This PR adds the shared contract layer for standard wire-format handling in nats-agent-core.**

It introduces a centralized place for:

standard envelope/model encode/decode handling
transport-level validation for shared public envelope/models
consistent preservation of core wire-contract fields (version, rpc_id, target, uuid, action, timestamp)
It also includes one minimal public contract correction:

StatusEnvelope now includes optional uuid to support configure outcome identity semantics.
**Why**
Phase 1 established the public API surface, but the library still needed a shared contract layer so later phases do not duplicate or fragment wire-format handling.

**Scope**
This PR is limited to the Phase 2 contract-layer feature:

internal/contract/helpers.go
internal/contract/validate.go
internal/contract/codec.go
minimal compatibility update in agentcore/contracts.go (StatusEnvelope.UUID)
**Requirements**
NATS-LIB-08
NATS-LIB-09
NATS-LIB-10
NATS-LIB-14
(partial semantic support) NATS-LIB-31