### PR TITLE
feat(messaging): add phase-3 subject helpers and shared publish paths

### DIFF
--- a/PROMPTS/03-subjects-publish-paths.md
+++ b/PROMPTS/03-subjects-publish-paths.md
@@ -1,0 +1,99 @@
+Read PROMPTS/IMPLEMENTATION_PROMPT.md carefully.
+Also read SPEC.md for additional design context.
+Use PROMPTS/IMPLEMENTATION_PROMPT.md as the primary implementation source of truth for code generation scope, API shape, and wire-contract behavior.
+
+Also read REQUIREMENTS_CHECKLIST.md and the current codebase carefully.
+
+Build on the already-corrected Phase 1 and Phase 2 code.
+Treat the current public types and method signatures as the baseline unless a minimal compatibility correction is absolutely required.
+
+Now implement only:
+1. internal/subjects
+2. centralized subject generation helpers
+3. subject validation helpers
+4. shared publish wrappers for major message types
+5. configure store-then-notify publish path
+6. explicit shared helpers for result and status publication
+
+Requirements to focus on:
+- NATS-LIB-12
+- NATS-LIB-15
+- NATS-LIB-20
+- NATS-LIB-21
+- NATS-LIB-22
+
+Goal:
+Add the shared messaging layer for subject creation and publish paths so routing stays centralized, publish behavior is reusable, and configure follows the required durable store-then-notify flow.
+
+Rules:
+- Centralize all subject generation in one internal package
+- Reject malformed target/action routing inputs early
+- Do not scatter raw subject strings across the codebase
+- Implement configure, action, result, and status subject helpers
+- Subject helpers are shared routing helpers for both publish-side and subscribe-side use, even though subscribe wrapper APIs are deferred to a later phase
+- Keep shared publish logic centralized, small, and reusable
+- Configure must follow store-then-notify, not direct full-config publish only
+- Result and status publication must go through explicit shared helpers
+- Reuse Phase 2 contract/codec/validation helpers where appropriate
+- Do not implement subscribe wrappers yet
+- Do not implement handler registration yet
+- Do not implement reconnect restoration yet
+- Do not implement receive-side result correlation logic in this phase
+- Do not add tests in this phase
+- Keep code modular, testable, and race-safe
+- Do not invent extra domain-specific routing patterns not present in PROMPTS/IMPLEMENTATION_PROMPT.md or REQUIREMENTS_CHECKLIST.md
+
+Subject expectations:
+- Configure subject: cmd.configure.%s
+- Action subject: cmd.action.%s.%s
+- Result subject: result.%s
+- Status subject: status.%s
+
+Validation expectations:
+- Validate target values used in subject construction
+- Validate action values used in action subject construction
+- Reject malformed or empty routing identifiers where required
+- Keep validation limited to shared routing/subject sanity only
+- Do not embed workload/business meaning into subject validation
+
+Publish path expectations:
+- Configure flow must:
+  1. validate the configure request
+  2. store desired configuration through the shared durable storage path
+  3. publish a lightweight configure notification only after storage succeeds
+- Action flow must publish through a shared helper using centralized subject builders
+- Result flow must publish through an explicit shared helper
+- Status flow must publish through an explicit shared helper
+- Publish helpers should avoid ad hoc raw subject construction and duplicated publish logic
+
+Suggested files:
+- internal/subjects/subjects.go
+- internal/subjects/validate.go
+- internal/transport/publish.go
+- internal/transport/configure.go
+
+Add more small focused files only if clearly needed.
+
+After coding:
+- summarize exactly which files were added or changed
+- explain how the implementation aligns with PROMPTS/IMPLEMENTATION_PROMPT.md
+- map each added/changed file to the relevant requirement IDs from REQUIREMENTS_CHECKLIST.md, especially:
+  - NATS-LIB-12
+  - NATS-LIB-15
+  - NATS-LIB-20
+  - NATS-LIB-21
+  - NATS-LIB-22
+- list any minimal public API adjustments made, if any
+- list what is intentionally deferred to later phases
+
+Review checklist for this phase:
+- configure, action, result, and status subject helpers exist
+- malformed target/action inputs are rejected
+- one place for subject creation exists
+- subject helpers are reusable by future subscribe-side code as well as current publish-side code
+- common publish wrappers exist for major message types
+- configure follows store-then-notify
+- result and status use explicit shared publish helpers
+- raw subject strings are not scattered through the codebase
+- no subscribe/handler/reconnect logic leaked into this phase
+- no workload/business logic was added

--- a/PROMPTS/03-subjects-publish-tests.md
+++ b/PROMPTS/03-subjects-publish-tests.md
@@ -1,0 +1,174 @@
+Read PROMPTS/TESTS_STANDARD_TEMPLATE.md first and follow it exactly for:
+- structure
+- wording
+- formatting
+- naming
+- comment style
+
+Also read:
+- SPEC.md
+- REQUIREMENTS_CHECKLIST.md
+- current codebase
+
+Generate unit tests only for the implemented Phase 3 messaging code in:
+
+- internal/subjects/subjects.go
+- internal/subjects/validate.go
+- internal/transport/publish.go
+- internal/transport/configure.go
+
+Requirements to focus on:
+- NATS-LIB-12
+- NATS-LIB-15
+- NATS-LIB-20
+- NATS-LIB-21
+- NATS-LIB-22
+
+Add tests in these files:
+- internal/subjects/validate_test.go
+- internal/subjects/subjects_test.go
+- internal/transport/publish_test.go
+- internal/transport/configure_test.go
+
+Test only implemented behavior.
+
+General test design rules:
+- For each function under test, cover:
+  1. valid success path
+  2. direct validation failure
+  3. dependency failure
+  4. multi-step boundary failure if the function performs more than one operation
+  5. side-effect assertions such as call count, call order, and publish/store not called when they should not be
+- For every multi-step flow, add one test for each failure boundary, not only the first failure path
+- If a function does validate -> store -> publish, test:
+  - validation fails before store
+  - store fails before publish
+  - publish fails after successful store
+  - success path
+- On failure, assert whether returned ack/result should be nil where applicable
+- Always assert whether downstream side effects were skipped or already performed
+- Prefer wrapper-level tests, not only shared helper tests, for invalid input and publish failure paths
+- Keep tests readable, deterministic, and focused
+- Use small test doubles and explicit assertions rather than over-abstracting test helpers
+
+Priority order:
+
+1. Subject validation
+Cover:
+- ValidateTarget
+- ValidateAction
+- validatePattern
+
+Include positive and negative tests for:
+- valid target/action
+- empty or whitespace-only values
+- embedded whitespace
+- '.'
+- wildcard tokens '*' and '>'
+- unsupported characters
+- valid placeholder count
+- invalid placeholder count
+- unsupported format directives
+- pattern whitespace
+- wildcard in pattern
+
+2. Subject builders
+Cover:
+- DefaultPatterns
+- PatternsFromConfig
+- NewBuilder
+- NewDefaultBuilder
+- ConfigureSubject
+- ActionSubject
+- ResultSubject
+- StatusSubject
+- HealthSubject
+
+Include tests for:
+- defaults are returned correctly
+- empty config preserves defaults
+- partial override preserves defaults for unspecified patterns
+- valid overrides are accepted
+- invalid patterns are rejected
+- valid subjects are built correctly
+- invalid target/action is rejected
+
+3. Publish paths
+Cover:
+- NewPublishPaths
+- PublishConfigureNotification
+- SubmitAction
+- PublishResult
+- PublishStatus
+- publishEncoded
+
+Include tests for:
+- nil builder rejected
+- nil publisher rejected
+- publish failure wrapped as CodePublishFailed
+- success path publishes expected subject
+- success path publishes encoded payload
+- SubmitAction returns SubmissionAck with correct fields
+- custom/internal clock is used for AcceptedAt if implementation supports it
+- SubmitAction rejects invalid target before publish
+- SubmitAction rejects invalid action before publish
+- PublishResult rejects invalid target before publish
+- PublishStatus rejects invalid target before publish
+- PublishResult wraps publisher failure
+- PublishStatus wraps publisher failure
+
+4. Configure paths
+Cover:
+- NewConfigurePaths
+- SubmitConfigure
+- buildKVKey
+
+Include tests for:
+- nil store rejected
+- nil publisher rejected
+- default bucket/key pattern used when config is empty
+- custom now function stored and used
+- invalid configure command rejected before store
+- store failure wrapped as CodeKVStoreFailed
+- nil stored result rejected
+- stored bucket/key used when present
+- fallback bucket/key generation used when missing
+- buildKVKey success path
+- buildKVKey invalid pattern failures
+- configure flow is store first, then notify
+- notify publish does not happen when store fails
+- store succeeds but notify publish fails
+- publish failure after successful store returns CodePublishFailed
+- ack is nil when notify publish fails
+- store is still called exactly once before publish failure is returned
+- configure publish failure does not appear as store failure
+- returned SubmissionAck contains expected fields
+
+Use small test doubles for:
+- Publisher
+- DesiredConfigStore
+
+The test doubles should let you assert:
+- call count
+- call order
+- published subject
+- published payload
+- returned errors
+- stored result values
+
+Do not add tests for:
+- subscribe wrappers
+- handler registration
+- reconnect restore
+- public agentcore.Client wiring
+- receive-side result correlation
+- NATS/JetStream integration
+- future phases
+
+At the end, provide:
+- files added
+- files modified
+- positive coverage summary
+- negative coverage summary
+- any existing tests changed and why
+- any intentionally deferred gaps

--- a/PROMPTS/TESTS_STANDARD_TEMPLATE.md
+++ b/PROMPTS/TESTS_STANDARD_TEMPLATE.md
@@ -1,0 +1,136 @@
+Read this file first before generating or modifying any test cases.
+
+This file is the source of truth for:
+- test structure
+- wording
+- formatting
+- naming style
+- comment style
+- positive/negative coverage style
+- consistency of the test suite
+
+Use this file as the fixed standard for writing tests.
+
+Also read:
+- SPEC.md
+- REQUIREMENTS_CHECKLIST.md
+- the current codebase
+- existing test files in the repository, if present
+
+Core objective:
+Generate unit tests that are structurally consistent, readable, minimal, and behavior-focused.
+
+Most important rule:
+Existing repository test files, if present, are the style reference.
+Follow their structure and wording closely.
+Do not invent a new test style unless no prior test style exists yet.
+
+Scope rules:
+- Test only behavior that is actually implemented in the code.
+- Do not write speculative tests for unimplemented behavior.
+- Do not add integration, runtime, end-to-end, or external-system tests unless explicitly requested.
+- Do not fake coverage for functionality that does not exist yet.
+- Keep tests aligned to real code, not ideal future design.
+
+Coverage rules:
+- Include both positive and negative tests where meaningful.
+- Cover required behavior first.
+- Add edge-case tests only when they directly protect implemented behavior.
+- Avoid unnecessary clutter and redundant tests.
+- Prefer a small, strong test set over a large noisy one.
+
+Required style:
+- Keep tests small, focused, and readable.
+- Prefer explicit and descriptive test names.
+- Use table-driven tests only where they improve clarity.
+- Keep helper naming consistent within the suite.
+- Keep assertions straightforward and readable.
+- Keep files gofmt-compatible.
+- Keep tests beside the package they test unless a different repository pattern already exists.
+
+Required comment format above every test function:
+
+/*
+TC-<AREA>-<NUMBER>
+Type: Positive|Negative
+Title: <short heading>
+Summary:
+<2-4 line plain-English summary of the test>
+
+Validates:
+  - <point 1>
+  - <point 2>
+  - <point 3 if needed>
+*/
+
+Comment rules:
+- Preserve this structure exactly.
+- Use simple, clear English.
+- Keep wording consistent across the suite.
+- Do not switch to a different documentation style.
+- Do not omit the comment block.
+
+Naming rules:
+- Use `TestXxx...` Go naming.
+- Keep test names explicit and behavior-oriented.
+- Prefer names that describe what behavior is being validated.
+- Keep TC numbering and area prefixes consistent within the suite.
+
+Assertion rules:
+- Assert behavior first.
+- Prefer direct assertions unless a helper clearly reduces duplication.
+- Do not assert internal trivia unless that internal detail is the actual behavior being tested.
+- If the code returns typed errors, assert typed error fields only when that behavior exists in code.
+- If the code returns plain errors, do not force typed error assertions.
+
+Modification rules:
+- Do not rewrite existing tests unless the actual behavior or public contract has changed.
+- If an existing test must be modified, explain exactly why.
+- Keep stable behavior tests unchanged.
+
+Before writing tests:
+Inspect the repository and preserve:
+- TC naming pattern
+- comment wording pattern
+- helper naming pattern
+- assertion pattern
+- file organization pattern
+- overall detail level
+
+When identifying tests to add, consider:
+- newly added public behavior
+- newly added internal helpers
+- validation behavior
+- codec or serialization behavior
+- lifecycle or state behavior
+- error behavior
+- positive cases
+- negative cases
+- directly relevant edge cases tied to implemented behavior
+
+Do not include:
+- speculative future-behavior assertions
+- unrelated cleanup
+- unnecessary refactors
+- duplicate tests that only restate existing coverage
+- tests for features not implemented in the code
+
+Expected output:
+1. Add or update the required unit tests.
+2. Keep formatting clean and consistent with the suite.
+3. After generating tests, provide a summary containing:
+   - files added
+   - files modified
+   - positive cases covered
+   - negative cases covered
+   - existing tests changed and why
+   - remaining gaps intentionally deferred
+
+Final verification checklist:
+- tests match repository suite style
+- header comments match the required format exactly
+- wording is consistent across the suite
+- only implemented behavior is tested
+- positive and negative coverage are both present where meaningful
+- no future behavior was accidentally tested
+- tests remain minimal but sufficient

--- a/README.md
+++ b/README.md
@@ -34,21 +34,22 @@ In simple words:
 
 ## Current status
 
-This repository is currently at **Phase 1 bootstrap + Phase 2 contract layer**.
+This repository currently includes **Phase 1 bootstrap + Phase 2 contract layer + Phase 3 messaging foundations**.
 
 Current code includes:
 - public config types
-- public client method signatures
+- public client facade method signatures
 - standard envelope and storage models
 - typed public errors
 - logger and metrics interfaces
 - shared contract codec helpers (`internal/contract`)
 - shared contract validation helpers (`internal/contract`)
+- centralized subject generation and validation helpers (`internal/subjects`)
+- shared publish wrappers and configure store-then-notify groundwork (`internal/transport`)
 
-Runtime transport behavior is intentionally **not implemented yet** in this
-phase set. That means transport/session/KV/subject/publish-subscribe/reconnect
-runtime execution logic is
-deferred to later phases.
+Full runtime session/JetStream/KV wiring, subscribe/handler runtime flow,
+reconnect restoration, and public `agentcore.Client` method wiring are
+intentionally deferred to later phases.
 
 ---
 
@@ -57,7 +58,7 @@ deferred to later phases.
 The intended end-state of this library is to help agents:
 
 This section describes the target design and is not fully implemented in the
-current Phase 1 + Phase 2 state.
+current Phase 1 + Phase 2 + Phase 3 foundation state.
 
 - connect to NATS
 - reconnect after temporary disconnects
@@ -103,7 +104,7 @@ The library is designed around the idea that agents use shared transport/state h
 ## Basic communication model
 
 The flows below describe the target design. They are not fully implemented in
-the current Phase 1 + Phase 2 state.
+the current Phase 1 + Phase 2 + Phase 3 foundation state.
 
 ### Configure flow
 

--- a/internal/subjects/subjects.go
+++ b/internal/subjects/subjects.go
@@ -1,0 +1,155 @@
+package subjects
+
+import (
+	"fmt"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+const (
+	// DefaultConfigurePattern is the standard configure routing pattern.
+	DefaultConfigurePattern = "cmd.configure.%s"
+	// DefaultActionPattern is the standard action routing pattern.
+	DefaultActionPattern = "cmd.action.%s.%s"
+	// DefaultResultPattern is the standard result routing pattern.
+	DefaultResultPattern = "result.%s"
+	// DefaultStatusPattern is the standard status routing pattern.
+	DefaultStatusPattern = "status.%s"
+	// DefaultHealthPattern is the standard health routing pattern.
+	DefaultHealthPattern = "health.%s"
+)
+
+// Patterns contains all subject patterns used by routing helpers.
+type Patterns struct {
+	ConfigurePattern string
+	ActionPattern    string
+	ResultPattern    string
+	StatusPattern    string
+	HealthPattern    string
+}
+
+// DefaultPatterns returns the default routing patterns.
+func DefaultPatterns() Patterns {
+	return Patterns{
+		ConfigurePattern: DefaultConfigurePattern,
+		ActionPattern:    DefaultActionPattern,
+		ResultPattern:    DefaultResultPattern,
+		StatusPattern:    DefaultStatusPattern,
+		HealthPattern:    DefaultHealthPattern,
+	}
+}
+
+// PatternsFromConfig resolves configured patterns while preserving defaults.
+func PatternsFromConfig(cfg agentcore.SubjectConfig) (Patterns, error) {
+	p := DefaultPatterns()
+
+	if cfg.ConfigurePattern != "" {
+		p.ConfigurePattern = cfg.ConfigurePattern
+	}
+	if cfg.ActionPattern != "" {
+		p.ActionPattern = cfg.ActionPattern
+	}
+	if cfg.ResultPattern != "" {
+		p.ResultPattern = cfg.ResultPattern
+	}
+	if cfg.StatusPattern != "" {
+		p.StatusPattern = cfg.StatusPattern
+	}
+	if cfg.HealthPattern != "" {
+		p.HealthPattern = cfg.HealthPattern
+	}
+
+	if err := validatePattern("configure_pattern", p.ConfigurePattern, 1); err != nil {
+		return Patterns{}, err
+	}
+	if err := validatePattern("action_pattern", p.ActionPattern, 2); err != nil {
+		return Patterns{}, err
+	}
+	if err := validatePattern("result_pattern", p.ResultPattern, 1); err != nil {
+		return Patterns{}, err
+	}
+	if err := validatePattern("status_pattern", p.StatusPattern, 1); err != nil {
+		return Patterns{}, err
+	}
+	if err := validatePattern("health_pattern", p.HealthPattern, 1); err != nil {
+		return Patterns{}, err
+	}
+
+	return p, nil
+}
+
+// Builder centralizes subject generation for publish and subscribe paths.
+type Builder struct {
+	patterns Patterns
+}
+
+// NewBuilder creates a Builder with validated patterns.
+func NewBuilder(patterns Patterns) (*Builder, error) {
+	if err := validatePattern("configure_pattern", patterns.ConfigurePattern, 1); err != nil {
+		return nil, err
+	}
+	if err := validatePattern("action_pattern", patterns.ActionPattern, 2); err != nil {
+		return nil, err
+	}
+	if err := validatePattern("result_pattern", patterns.ResultPattern, 1); err != nil {
+		return nil, err
+	}
+	if err := validatePattern("status_pattern", patterns.StatusPattern, 1); err != nil {
+		return nil, err
+	}
+	if err := validatePattern("health_pattern", patterns.HealthPattern, 1); err != nil {
+		return nil, err
+	}
+
+	return &Builder{patterns: patterns}, nil
+}
+
+// NewDefaultBuilder creates a Builder using default patterns.
+func NewDefaultBuilder() *Builder {
+	builder, _ := NewBuilder(DefaultPatterns())
+	return builder
+}
+
+// ConfigureSubject builds the configure subject for a target.
+func (b *Builder) ConfigureSubject(target string) (string, error) {
+	if err := ValidateTarget(target); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(b.patterns.ConfigurePattern, target), nil
+}
+
+// ActionSubject builds the action subject for a target and action.
+func (b *Builder) ActionSubject(target, action string) (string, error) {
+	if err := ValidateTarget(target); err != nil {
+		return "", err
+	}
+	if err := ValidateAction(action); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(b.patterns.ActionPattern, target, action), nil
+}
+
+// ResultSubject builds the result subject for a target.
+func (b *Builder) ResultSubject(target string) (string, error) {
+	if err := ValidateTarget(target); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(b.patterns.ResultPattern, target), nil
+}
+
+// StatusSubject builds the status subject for a target.
+func (b *Builder) StatusSubject(target string) (string, error) {
+	if err := ValidateTarget(target); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(b.patterns.StatusPattern, target), nil
+}
+
+// HealthSubject builds the health subject for a target.
+func (b *Builder) HealthSubject(target string) (string, error) {
+	if err := ValidateTarget(target); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(b.patterns.HealthPattern, target), nil
+}
+

--- a/internal/subjects/subjects_test.go
+++ b/internal/subjects/subjects_test.go
@@ -1,0 +1,369 @@
+package subjects
+
+import (
+	"testing"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+/*
+TC-SUBJECTS-BUILDER-001
+Type: Positive
+Title: DefaultPatterns returns standard routing defaults
+Summary:
+Verifies that default pattern generation returns the expected target-oriented
+subject formats for configure action result status and health.
+
+Validates:
+  - configure and action defaults match the standard contract
+  - result status and health defaults match the standard contract
+*/
+func TestDefaultPatternsReturnsStandardDefaults(t *testing.T) {
+	got := DefaultPatterns()
+
+	if got.ConfigurePattern != DefaultConfigurePattern {
+		t.Fatalf("expected ConfigurePattern %q, got %q", DefaultConfigurePattern, got.ConfigurePattern)
+	}
+	if got.ActionPattern != DefaultActionPattern {
+		t.Fatalf("expected ActionPattern %q, got %q", DefaultActionPattern, got.ActionPattern)
+	}
+	if got.ResultPattern != DefaultResultPattern {
+		t.Fatalf("expected ResultPattern %q, got %q", DefaultResultPattern, got.ResultPattern)
+	}
+	if got.StatusPattern != DefaultStatusPattern {
+		t.Fatalf("expected StatusPattern %q, got %q", DefaultStatusPattern, got.StatusPattern)
+	}
+	if got.HealthPattern != DefaultHealthPattern {
+		t.Fatalf("expected HealthPattern %q, got %q", DefaultHealthPattern, got.HealthPattern)
+	}
+}
+
+/*
+TC-SUBJECTS-BUILDER-002
+Type: Positive
+Title: PatternsFromConfig preserves defaults for empty config
+Summary:
+Verifies that pattern resolution keeps all default values when subject config
+does not provide overrides.
+
+Validates:
+  - empty config returns default configure action result status and health patterns
+*/
+func TestPatternsFromConfigPreservesDefaultsForEmptyConfig(t *testing.T) {
+	got, err := PatternsFromConfig(agentcore.SubjectConfig{})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	want := DefaultPatterns()
+	if got != want {
+		t.Fatalf("expected patterns %+v, got %+v", want, got)
+	}
+}
+
+/*
+TC-SUBJECTS-BUILDER-003
+Type: Positive
+Title: PatternsFromConfig accepts valid overrides
+Summary:
+Verifies that pattern resolution accepts valid subject overrides while keeping
+validation constraints enforced.
+
+Validates:
+  - configured patterns override defaults
+  - valid override set passes pattern validation
+*/
+func TestPatternsFromConfigAcceptsValidOverrides(t *testing.T) {
+	cfg := agentcore.SubjectConfig{
+		ConfigurePattern: "custom.cfg.%s",
+		ActionPattern:    "custom.act.%s.%s",
+		ResultPattern:    "custom.result.%s",
+		StatusPattern:    "custom.status.%s",
+		HealthPattern:    "custom.health.%s",
+	}
+
+	got, err := PatternsFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if got.ConfigurePattern != cfg.ConfigurePattern {
+		t.Fatalf("expected ConfigurePattern %q, got %q", cfg.ConfigurePattern, got.ConfigurePattern)
+	}
+	if got.ActionPattern != cfg.ActionPattern {
+		t.Fatalf("expected ActionPattern %q, got %q", cfg.ActionPattern, got.ActionPattern)
+	}
+	if got.ResultPattern != cfg.ResultPattern {
+		t.Fatalf("expected ResultPattern %q, got %q", cfg.ResultPattern, got.ResultPattern)
+	}
+	if got.StatusPattern != cfg.StatusPattern {
+		t.Fatalf("expected StatusPattern %q, got %q", cfg.StatusPattern, got.StatusPattern)
+	}
+	if got.HealthPattern != cfg.HealthPattern {
+		t.Fatalf("expected HealthPattern %q, got %q", cfg.HealthPattern, got.HealthPattern)
+	}
+}
+
+/*
+TC-SUBJECTS-BUILDER-004
+Type: Positive
+Title: PatternsFromConfig preserves defaults for unspecified partial overrides
+Summary:
+Verifies that pattern resolution applies only configured overrides and keeps
+default values for every unspecified pattern field.
+
+Validates:
+  - specified configure pattern override is applied
+  - unspecified patterns remain at defaults
+*/
+func TestPatternsFromConfigPreservesDefaultsForPartialOverrides(t *testing.T) {
+	cfg := agentcore.SubjectConfig{
+		ConfigurePattern: "custom.cfg.%s",
+	}
+
+	got, err := PatternsFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if got.ConfigurePattern != "custom.cfg.%s" {
+		t.Fatalf("expected ConfigurePattern %q, got %q", "custom.cfg.%s", got.ConfigurePattern)
+	}
+	if got.ActionPattern != DefaultActionPattern {
+		t.Fatalf("expected ActionPattern %q, got %q", DefaultActionPattern, got.ActionPattern)
+	}
+	if got.ResultPattern != DefaultResultPattern {
+		t.Fatalf("expected ResultPattern %q, got %q", DefaultResultPattern, got.ResultPattern)
+	}
+	if got.StatusPattern != DefaultStatusPattern {
+		t.Fatalf("expected StatusPattern %q, got %q", DefaultStatusPattern, got.StatusPattern)
+	}
+	if got.HealthPattern != DefaultHealthPattern {
+		t.Fatalf("expected HealthPattern %q, got %q", DefaultHealthPattern, got.HealthPattern)
+	}
+}
+
+/*
+TC-SUBJECTS-BUILDER-005
+Type: Negative
+Title: PatternsFromConfig rejects invalid configured patterns
+Summary:
+Verifies that configured pattern overrides are validated and rejected when they
+violate subject pattern constraints.
+
+Validates:
+  - invalid configured action placeholder count fails
+  - error preserves subject-pattern validator op
+*/
+func TestPatternsFromConfigRejectsInvalidConfiguredPatterns(t *testing.T) {
+	cfg := agentcore.SubjectConfig{
+		ActionPattern: "cmd.action.%s",
+	}
+
+	_, err := PatternsFromConfig(cfg)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_subject_pattern", "action_pattern placeholder count is invalid")
+}
+
+/*
+TC-SUBJECTS-BUILDER-006
+Type: Positive
+Title: NewBuilder accepts valid patterns
+Summary:
+Verifies that builder construction succeeds for a valid full pattern set.
+
+Validates:
+  - NewBuilder returns a non-nil builder for valid patterns
+*/
+func TestNewBuilderAcceptsValidPatterns(t *testing.T) {
+	builder, err := NewBuilder(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if builder == nil {
+		t.Fatal("expected non-nil builder")
+	}
+}
+
+/*
+TC-SUBJECTS-BUILDER-007
+Type: Negative
+Title: NewBuilder rejects invalid patterns
+Summary:
+Verifies that builder construction rejects invalid pattern sets before the
+builder is created.
+
+Validates:
+  - malformed configure pattern fails validation
+  - error preserves subject-pattern validator op
+*/
+func TestNewBuilderRejectsInvalidPatterns(t *testing.T) {
+	patterns := DefaultPatterns()
+	patterns.ConfigurePattern = "cmd.configure.*"
+
+	_, err := NewBuilder(patterns)
+	requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_subject_pattern", "configure_pattern cannot contain wildcard tokens")
+}
+
+/*
+TC-SUBJECTS-BUILDER-008
+Type: Positive
+Title: NewDefaultBuilder provides working default builder
+Summary:
+Verifies that the default builder helper returns a usable builder configured
+with standard defaults.
+
+Validates:
+  - default builder is non-nil
+  - configure subject generation works with defaults
+*/
+func TestNewDefaultBuilderProvidesWorkingDefaultBuilder(t *testing.T) {
+	builder := NewDefaultBuilder()
+	if builder == nil {
+		t.Fatal("expected non-nil builder")
+	}
+
+	subject, err := builder.ConfigureSubject("vyos")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if subject != "cmd.configure.vyos" {
+		t.Fatalf("expected subject %q, got %q", "cmd.configure.vyos", subject)
+	}
+}
+
+/*
+TC-SUBJECTS-BUILDER-009
+Type: Positive
+Title: Builder methods generate expected subjects for valid inputs
+Summary:
+Verifies that all builder methods generate the expected subject values for
+valid target and action tokens.
+
+Validates:
+  - configure action result status and health subjects are built correctly
+*/
+func TestBuilderMethodsGenerateExpectedSubjects(t *testing.T) {
+	builder, err := NewBuilder(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	configureSubject, err := builder.ConfigureSubject("vyos")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if configureSubject != "cmd.configure.vyos" {
+		t.Fatalf("expected configure subject %q, got %q", "cmd.configure.vyos", configureSubject)
+	}
+
+	actionSubject, err := builder.ActionSubject("vyos", "trace")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if actionSubject != "cmd.action.vyos.trace" {
+		t.Fatalf("expected action subject %q, got %q", "cmd.action.vyos.trace", actionSubject)
+	}
+
+	resultSubject, err := builder.ResultSubject("vyos")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resultSubject != "result.vyos" {
+		t.Fatalf("expected result subject %q, got %q", "result.vyos", resultSubject)
+	}
+
+	statusSubject, err := builder.StatusSubject("vyos")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if statusSubject != "status.vyos" {
+		t.Fatalf("expected status subject %q, got %q", "status.vyos", statusSubject)
+	}
+
+	healthSubject, err := builder.HealthSubject("vyos")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if healthSubject != "health.vyos" {
+		t.Fatalf("expected health subject %q, got %q", "health.vyos", healthSubject)
+	}
+}
+
+/*
+TC-SUBJECTS-BUILDER-010
+Type: Negative
+Title: Builder methods reject invalid target and action inputs
+Summary:
+Verifies that builder methods enforce token validation and reject invalid
+target or action inputs.
+
+Validates:
+  - subject methods requiring target reject invalid target
+  - action subject rejects invalid action token
+*/
+func TestBuilderMethodsRejectInvalidTargetAndAction(t *testing.T) {
+	builder, err := NewBuilder(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		call    func() error
+		wantOp  string
+		msgPart string
+	}{
+		{
+			name: "configure invalid target",
+			call: func() error {
+				_, err := builder.ConfigureSubject("vyos core")
+				return err
+			},
+			wantOp:  "validate_target",
+			msgPart: "target cannot contain whitespace",
+		},
+		{
+			name: "result invalid target",
+			call: func() error {
+				_, err := builder.ResultSubject("vyos>")
+				return err
+			},
+			wantOp:  "validate_target",
+			msgPart: "target cannot contain wildcard tokens",
+		},
+		{
+			name: "status invalid target",
+			call: func() error {
+				_, err := builder.StatusSubject("vyos.core")
+				return err
+			},
+			wantOp:  "validate_target",
+			msgPart: "target cannot contain '.'",
+		},
+		{
+			name: "health invalid target",
+			call: func() error {
+				_, err := builder.HealthSubject("vyos/core")
+				return err
+			},
+			wantOp:  "validate_target",
+			msgPart: "target contains unsupported characters",
+		},
+		{
+			name: "action invalid action",
+			call: func() error {
+				_, err := builder.ActionSubject("vyos", "re boot")
+				return err
+			},
+			wantOp:  "validate_action",
+			msgPart: "action cannot contain whitespace",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			requireAgentcoreError(t, err, agentcore.CodeValidation, tc.wantOp, tc.msgPart)
+		})
+	}
+}

--- a/internal/subjects/validate.go
+++ b/internal/subjects/validate.go
@@ -1,0 +1,85 @@
+package subjects
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+func validationError(op, msg string) error {
+	return &agentcore.Error{
+		Code:      agentcore.CodeValidation,
+		Op:        op,
+		Message:   msg,
+		Retryable: false,
+	}
+}
+
+// ValidateTarget validates target identifiers used for subject construction.
+func ValidateTarget(target string) error {
+	const op = "validate_target"
+
+	if strings.TrimSpace(target) == "" {
+		return validationError(op, "target is required")
+	}
+	return validateToken(op, "target", target)
+}
+
+// ValidateAction validates action identifiers used for subject construction.
+func ValidateAction(action string) error {
+	const op = "validate_action"
+
+	if strings.TrimSpace(action) == "" {
+		return validationError(op, "action is required")
+	}
+	return validateToken(op, "action", action)
+}
+
+func validateToken(op, field, value string) error {
+	if strings.ContainsAny(value, " \t\r\n") {
+		return validationError(op, field+" cannot contain whitespace")
+	}
+	if strings.Contains(value, ".") {
+		return validationError(op, field+" cannot contain '.'")
+	}
+	if strings.Contains(value, "*") || strings.Contains(value, ">") {
+		return validationError(op, field+" cannot contain wildcard tokens")
+	}
+
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' {
+			continue
+		}
+		return validationError(op, field+" contains unsupported characters")
+	}
+
+	return nil
+}
+
+func validatePattern(name, pattern string, placeholders int) error {
+	const op = "validate_subject_pattern"
+
+	if strings.TrimSpace(pattern) == "" {
+		return validationError(op, name+" is required")
+	}
+	if strings.ContainsAny(pattern, " \t\r\n") {
+		return validationError(op, name+" cannot contain whitespace")
+	}
+	if strings.Contains(pattern, "*") || strings.Contains(pattern, ">") {
+		return validationError(op, name+" cannot contain wildcard tokens")
+	}
+
+	count := strings.Count(pattern, "%s")
+	if count != placeholders {
+		return validationError(op, name+" placeholder count is invalid")
+	}
+
+	residual := strings.ReplaceAll(pattern, "%s", "")
+	if strings.Contains(residual, "%") {
+		return validationError(op, name+" contains unsupported format directives")
+	}
+
+	return nil
+}
+

--- a/internal/subjects/validate_test.go
+++ b/internal/subjects/validate_test.go
@@ -1,0 +1,292 @@
+package subjects
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+)
+
+func requireAgentcoreError(t *testing.T, err error, wantCode agentcore.Code, wantOp string, wantMsgPart string) *agentcore.Error {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+
+	var got *agentcore.Error
+	if !errors.As(err, &got) {
+		t.Fatalf("expected *agentcore.Error, got %T", err)
+	}
+	if got.Code != wantCode {
+		t.Fatalf("expected error code %q, got %q", wantCode, got.Code)
+	}
+	if got.Op != wantOp {
+		t.Fatalf("expected error op %q, got %q", wantOp, got.Op)
+	}
+	if wantMsgPart != "" && !strings.Contains(got.Message, wantMsgPart) {
+		t.Fatalf("expected error message to contain %q, got %q", wantMsgPart, got.Message)
+	}
+	return got
+}
+
+/*
+TC-SUBJECTS-VALIDATE-001
+Type: Positive
+Title: ValidateTarget accepts a valid target token
+Summary:
+Verifies that target validation succeeds for a normal subject token that
+matches allowed character rules.
+
+Validates:
+  - non-empty target is accepted
+  - target with letters digits underscore and hyphen is accepted
+*/
+func TestValidateTargetAcceptsValidTarget(t *testing.T) {
+	if err := ValidateTarget("vyos_1-edge"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-SUBJECTS-VALIDATE-002
+Type: Negative
+Title: ValidateTarget rejects malformed target values
+Summary:
+Verifies that target validation rejects malformed values that would produce
+unsafe or invalid subject tokens.
+
+Validates:
+  - empty or whitespace-only target fails
+  - embedded whitespace dot wildcard and unsupported characters fail
+*/
+func TestValidateTargetRejectsMalformedValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		msgPart string
+	}{
+		{
+			name:    "empty target",
+			target:  "   ",
+			msgPart: "target is required",
+		},
+		{
+			name:    "embedded whitespace",
+			target:  "vyos core",
+			msgPart: "target cannot contain whitespace",
+		},
+		{
+			name:    "dot token",
+			target:  "vyos.core",
+			msgPart: "target cannot contain '.'",
+		},
+		{
+			name:    "wildcard token",
+			target:  "vyos*",
+			msgPart: "target cannot contain wildcard tokens",
+		},
+		{
+			name:    "full wildcard token",
+			target:  "vyos>",
+			msgPart: "target cannot contain wildcard tokens",
+		},
+		{
+			name:    "unsupported character",
+			target:  "vyos/core",
+			msgPart: "target contains unsupported characters",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTarget(tc.target)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_target", tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-SUBJECTS-VALIDATE-003
+Type: Positive
+Title: ValidateAction accepts a valid action token
+Summary:
+Verifies that action validation succeeds for a normal action token using the
+allowed character set.
+
+Validates:
+  - non-empty action is accepted
+  - action with letters digits underscore and hyphen is accepted
+*/
+func TestValidateActionAcceptsValidAction(t *testing.T) {
+	if err := ValidateAction("trace_route-1"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+/*
+TC-SUBJECTS-VALIDATE-004
+Type: Negative
+Title: ValidateAction rejects malformed action values
+Summary:
+Verifies that action validation rejects malformed values that violate token
+rules used by subject builders.
+
+Validates:
+  - empty or whitespace-only action fails
+  - embedded whitespace dot wildcard and unsupported characters fail
+*/
+func TestValidateActionRejectsMalformedValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		msgPart string
+	}{
+		{
+			name:    "empty action",
+			action:  "\t",
+			msgPart: "action is required",
+		},
+		{
+			name:    "embedded whitespace",
+			action:  "re boot",
+			msgPart: "action cannot contain whitespace",
+		},
+		{
+			name:    "dot token",
+			action:  "re.boot",
+			msgPart: "action cannot contain '.'",
+		},
+		{
+			name:    "wildcard token",
+			action:  "re*boot",
+			msgPart: "action cannot contain wildcard tokens",
+		},
+		{
+			name:    "full wildcard token",
+			action:  "re>boot",
+			msgPart: "action cannot contain wildcard tokens",
+		},
+		{
+			name:    "unsupported character",
+			action:  "re/boot",
+			msgPart: "action contains unsupported characters",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAction(tc.action)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_action", tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-SUBJECTS-VALIDATE-005
+Type: Positive
+Title: validatePattern accepts valid subject patterns
+Summary:
+Verifies that internal subject pattern validation accepts valid pattern values
+with the expected placeholder count.
+
+Validates:
+  - one-placeholder patterns pass when placeholders is one
+  - two-placeholder action pattern passes when placeholders is two
+*/
+func TestValidatePatternAcceptsValidPatterns(t *testing.T) {
+	tests := []struct {
+		name         string
+		field        string
+		pattern      string
+		placeholders int
+	}{
+		{
+			name:         "configure pattern",
+			field:        "configure_pattern",
+			pattern:      "cmd.configure.%s",
+			placeholders: 1,
+		},
+		{
+			name:         "action pattern",
+			field:        "action_pattern",
+			pattern:      "cmd.action.%s.%s",
+			placeholders: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validatePattern(tc.field, tc.pattern, tc.placeholders); err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}
+
+/*
+TC-SUBJECTS-VALIDATE-006
+Type: Negative
+Title: validatePattern rejects invalid subject patterns
+Summary:
+Verifies that internal subject pattern validation rejects malformed patterns
+that violate whitespace wildcard placeholder or formatting rules.
+
+Validates:
+  - required pattern check fails for whitespace-only values
+  - wildcard and placeholder count checks fail for invalid patterns
+  - unsupported format directives are rejected
+*/
+func TestValidatePatternRejectsInvalidPatterns(t *testing.T) {
+	tests := []struct {
+		name         string
+		field        string
+		pattern      string
+		placeholders int
+		msgPart      string
+	}{
+		{
+			name:         "whitespace only pattern",
+			field:        "configure_pattern",
+			pattern:      "   ",
+			placeholders: 1,
+			msgPart:      "configure_pattern is required",
+		},
+		{
+			name:         "pattern contains whitespace",
+			field:        "configure_pattern",
+			pattern:      "cmd.configure. %s",
+			placeholders: 1,
+			msgPart:      "configure_pattern cannot contain whitespace",
+		},
+		{
+			name:         "pattern contains wildcard",
+			field:        "status_pattern",
+			pattern:      "status.*",
+			placeholders: 1,
+			msgPart:      "status_pattern cannot contain wildcard tokens",
+		},
+		{
+			name:         "invalid placeholder count",
+			field:        "result_pattern",
+			pattern:      "result.%s.%s",
+			placeholders: 1,
+			msgPart:      "result_pattern placeholder count is invalid",
+		},
+		{
+			name:         "unsupported format directive",
+			field:        "health_pattern",
+			pattern:      "health.%s.%d",
+			placeholders: 1,
+			msgPart:      "health_pattern contains unsupported format directives",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePattern(tc.field, tc.pattern, tc.placeholders)
+			requireAgentcoreError(t, err, agentcore.CodeValidation, "validate_subject_pattern", tc.msgPart)
+		})
+	}
+}

--- a/internal/transport/configure.go
+++ b/internal/transport/configure.go
@@ -165,10 +165,8 @@ func (c *ConfigurePaths) SubmitConfigure(ctx context.Context, cmd agentcore.Conf
 }
 
 func buildKVKey(pattern, target string) (string, error) {
-	if err := subjects.ValidateTarget(target); err != nil {
-		return "", err
-	}
-	if strings.TrimSpace(pattern) == "" {
+	trimmedPattern := strings.TrimSpace(pattern)
+	if trimmedPattern == "" {
 		return "", &agentcore.Error{
 			Code:      agentcore.CodeValidation,
 			Op:        "build_kv_key",
@@ -176,7 +174,17 @@ func buildKVKey(pattern, target string) (string, error) {
 			Retryable: false,
 		}
 	}
-	if strings.Count(pattern, "%s") != 1 {
+	// KV key patterns are validated as storage keys and intentionally remain
+	// separate from NATS subject-pattern validation rules.
+	if strings.ContainsAny(trimmedPattern, " \t\r\n") {
+		return "", &agentcore.Error{
+			Code:      agentcore.CodeValidation,
+			Op:        "build_kv_key",
+			Message:   "kv key pattern cannot contain whitespace",
+			Retryable: false,
+		}
+	}
+	if strings.Count(trimmedPattern, "%s") != 1 {
 		return "", &agentcore.Error{
 			Code:      agentcore.CodeValidation,
 			Op:        "build_kv_key",
@@ -184,5 +192,17 @@ func buildKVKey(pattern, target string) (string, error) {
 			Retryable: false,
 		}
 	}
-	return fmt.Sprintf(pattern, target), nil
+	residual := strings.ReplaceAll(trimmedPattern, "%s", "")
+	if strings.Contains(residual, "%") {
+		return "", &agentcore.Error{
+			Code:      agentcore.CodeValidation,
+			Op:        "build_kv_key",
+			Message:   "kv key pattern contains unsupported format directives",
+			Retryable: false,
+		}
+	}
+	if err := subjects.ValidateTarget(target); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(trimmedPattern, target), nil
 }

--- a/internal/transport/configure.go
+++ b/internal/transport/configure.go
@@ -1,0 +1,188 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+	"github.com/routerarchitects/nats-agent-core/internal/contract"
+	"github.com/routerarchitects/nats-agent-core/internal/subjects"
+)
+
+const (
+	defaultKVBucketPattern = "cfg_desired"
+	defaultKVKeyPattern    = "desired.%s"
+)
+
+// DesiredConfigStore stores desired configuration records durably.
+type DesiredConfigStore interface {
+	StoreDesiredConfig(ctx context.Context, record agentcore.DesiredConfigRecord) (*agentcore.StoredDesiredConfig, error)
+}
+
+// ConfigurePaths centralizes the configure store-then-notify publish path.
+type ConfigurePaths struct {
+	store        DesiredConfigStore
+	publisher    Publisher
+	publishPaths *PublishPaths
+	now          func() time.Time
+	kvBucket     string
+	kvKeyPattern string
+}
+
+// NewConfigurePaths creates a configure path helper with explicit dependencies.
+func NewConfigurePaths(
+	store DesiredConfigStore,
+	publisher Publisher,
+	subjectBuilder *subjects.Builder,
+	kvCfg agentcore.KVConfig,
+	now func() time.Time,
+) (*ConfigurePaths, error) {
+	if store == nil {
+		return nil, &agentcore.Error{
+			Code:      agentcore.CodeValidation,
+			Op:        "new_configure_paths",
+			Message:   "desired config store is required",
+			Retryable: false,
+		}
+	}
+	if publisher == nil {
+		return nil, &agentcore.Error{
+			Code:      agentcore.CodeValidation,
+			Op:        "new_configure_paths",
+			Message:   "publisher is required",
+			Retryable: false,
+		}
+	}
+	publishPaths, err := NewPublishPaths(subjectBuilder)
+	if err != nil {
+		return nil, err
+	}
+	if now == nil {
+		now = time.Now
+	}
+
+	bucket := strings.TrimSpace(kvCfg.Bucket)
+	if bucket == "" {
+		bucket = defaultKVBucketPattern
+	}
+
+	keyPattern := strings.TrimSpace(kvCfg.KeyPattern)
+	if keyPattern == "" {
+		keyPattern = defaultKVKeyPattern
+	}
+
+	return &ConfigurePaths{
+		store:        store,
+		publisher:    publisher,
+		publishPaths: publishPaths,
+		now:          now,
+		kvBucket:     bucket,
+		kvKeyPattern: keyPattern,
+	}, nil
+}
+
+// SubmitConfigure executes the shared configure flow:
+// 1) validate configure command
+// 2) store desired config durably
+// 3) publish lightweight configure notification
+func (c *ConfigurePaths) SubmitConfigure(ctx context.Context, cmd agentcore.ConfigureCommand) (*agentcore.SubmissionAck, error) {
+	if err := contract.ValidateConfigureCommand(cmd); err != nil {
+		return nil, err
+	}
+
+	record := agentcore.DesiredConfigRecord{
+		Version:   cmd.Version,
+		RPCID:     cmd.RPCID,
+		Target:    cmd.Target,
+		UUID:      cmd.UUID,
+		Payload:   cmd.Payload,
+		Timestamp: cmd.Timestamp,
+	}
+
+	stored, err := c.store.StoreDesiredConfig(ctx, record)
+	if err != nil {
+		return nil, &agentcore.Error{
+			Code:      agentcore.CodeKVStoreFailed,
+			Op:        "submit_configure_store",
+			Message:   "failed to store desired config",
+			Retryable: true,
+			Err:       err,
+		}
+	}
+	if stored == nil {
+		return nil, &agentcore.Error{
+			Code:      agentcore.CodeKVStoreFailed,
+			Op:        "submit_configure_store",
+			Message:   "desired config store returned nil result",
+			Retryable: true,
+		}
+	}
+
+	bucket := stored.Bucket
+	if bucket == "" {
+		bucket = c.kvBucket
+	}
+
+	key := stored.Key
+	if key == "" {
+		key, err = buildKVKey(c.kvKeyPattern, cmd.Target)
+		if err != nil {
+			return nil, err
+		}
+	}
+	configureSubject, err := c.publishPaths.subjects.ConfigureSubject(cmd.Target)
+	if err != nil {
+		return nil, err
+	}
+
+	notification := agentcore.ConfigureNotification{
+		Version:     cmd.Version,
+		RPCID:       cmd.RPCID,
+		Target:      cmd.Target,
+		CommandType: "configure",
+		UUID:        cmd.UUID,
+		KVBucket:    bucket,
+		KVKey:       key,
+		Timestamp:   c.now(),
+	}
+
+	if err := c.publishPaths.PublishConfigureNotification(ctx, c.publisher, notification); err != nil {
+		return nil, err
+	}
+
+	return &agentcore.SubmissionAck{
+		Accepted:   true,
+		RPCID:      cmd.RPCID,
+		Target:     cmd.Target,
+		Subject:    configureSubject,
+		AcceptedAt: notification.Timestamp,
+		KVBucket:   bucket,
+		KVKey:      key,
+		KVRevision: stored.Revision,
+	}, nil
+}
+
+func buildKVKey(pattern, target string) (string, error) {
+	if err := subjects.ValidateTarget(target); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(pattern) == "" {
+		return "", &agentcore.Error{
+			Code:      agentcore.CodeValidation,
+			Op:        "build_kv_key",
+			Message:   "kv key pattern is required",
+			Retryable: false,
+		}
+	}
+	if strings.Count(pattern, "%s") != 1 {
+		return "", &agentcore.Error{
+			Code:      agentcore.CodeValidation,
+			Op:        "build_kv_key",
+			Message:   "kv key pattern must contain exactly one %s placeholder",
+			Retryable: false,
+		}
+	}
+	return fmt.Sprintf(pattern, target), nil
+}

--- a/internal/transport/configure_test.go
+++ b/internal/transport/configure_test.go
@@ -1,0 +1,637 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+	"github.com/routerarchitects/nats-agent-core/internal/contract"
+	"github.com/routerarchitects/nats-agent-core/internal/subjects"
+)
+
+type storeCall struct {
+	record agentcore.DesiredConfigRecord
+}
+
+type stubDesiredConfigStore struct {
+	calls   []storeCall
+	result  *agentcore.StoredDesiredConfig
+	err     error
+	onStore func(record agentcore.DesiredConfigRecord)
+}
+
+func (s *stubDesiredConfigStore) StoreDesiredConfig(_ context.Context, record agentcore.DesiredConfigRecord) (*agentcore.StoredDesiredConfig, error) {
+	s.calls = append(s.calls, storeCall{record: record})
+	if s.onStore != nil {
+		s.onStore(record)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.result, nil
+}
+
+func validTransportConfigureCommand() agentcore.ConfigureCommand {
+	return agentcore.ConfigureCommand{
+		Version:   "1.0",
+		RPCID:     "rpc-config-1",
+		Target:    "vyos",
+		UUID:      "cfg-001",
+		Payload:   transportRawJSON(`{"hostname":"router-1"}`),
+		Timestamp: transportTestTime(),
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-001
+Type: Positive
+Title: NewConfigurePaths applies defaults when KV config and clock are empty
+Summary:
+Verifies that configure path construction initializes default KV bucket and key
+pattern values and a fallback internal clock when optional inputs are empty.
+
+Validates:
+  - default bucket and key pattern are stored
+  - fallback clock is initialized
+*/
+func TestNewConfigurePathsAppliesDefaults(t *testing.T) {
+	store := &stubDesiredConfigStore{}
+	pub := &stubPublisher{}
+
+	paths, err := NewConfigurePaths(store, pub, subjects.NewDefaultBuilder(), agentcore.KVConfig{}, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if paths == nil {
+		t.Fatal("expected non-nil configure paths")
+	}
+	if paths.kvBucket != defaultKVBucketPattern {
+		t.Fatalf("expected kvBucket %q, got %q", defaultKVBucketPattern, paths.kvBucket)
+	}
+	if paths.kvKeyPattern != defaultKVKeyPattern {
+		t.Fatalf("expected kvKeyPattern %q, got %q", defaultKVKeyPattern, paths.kvKeyPattern)
+	}
+	if paths.now == nil {
+		t.Fatal("expected configure paths clock to be initialized")
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-002
+Type: Positive
+Title: NewConfigurePaths stores custom KV config and custom clock
+Summary:
+Verifies that configure path construction preserves provided custom KV bucket,
+custom key pattern, and custom clock dependency.
+
+Validates:
+  - custom bucket and key pattern are stored
+  - custom clock is stored and callable
+*/
+func TestNewConfigurePathsStoresCustomKVConfigAndClock(t *testing.T) {
+	store := &stubDesiredConfigStore{}
+	pub := &stubPublisher{}
+	fixedNow := transportTestTime().Add(10 * time.Minute)
+
+	paths, err := NewConfigurePaths(
+		store,
+		pub,
+		subjects.NewDefaultBuilder(),
+		agentcore.KVConfig{Bucket: "custom_bucket", KeyPattern: "custom.%s"},
+		func() time.Time { return fixedNow },
+	)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if paths.kvBucket != "custom_bucket" {
+		t.Fatalf("expected kvBucket %q, got %q", "custom_bucket", paths.kvBucket)
+	}
+	if paths.kvKeyPattern != "custom.%s" {
+		t.Fatalf("expected kvKeyPattern %q, got %q", "custom.%s", paths.kvKeyPattern)
+	}
+	if !paths.now().Equal(fixedNow) {
+		t.Fatalf("expected custom clock value %v, got %v", fixedNow, paths.now())
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-003
+Type: Negative
+Title: NewConfigurePaths rejects missing required dependencies
+Summary:
+Verifies that configure path construction rejects missing store or publisher
+dependencies before creating the helper.
+
+Validates:
+  - nil store returns CodeValidation
+  - nil publisher returns CodeValidation
+*/
+func TestNewConfigurePathsRejectsMissingDependencies(t *testing.T) {
+	builder := subjects.NewDefaultBuilder()
+
+	_, err := NewConfigurePaths(nil, &stubPublisher{}, builder, agentcore.KVConfig{}, nil)
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "new_configure_paths", "desired config store is required")
+
+	_, err = NewConfigurePaths(&stubDesiredConfigStore{}, nil, builder, agentcore.KVConfig{}, nil)
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "new_configure_paths", "publisher is required")
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-004
+Type: Negative
+Title: NewConfigurePaths rejects invalid subject builder dependency
+Summary:
+Verifies that configure path construction propagates subject-builder validation
+when the builder dependency is missing.
+
+Validates:
+  - nil subject builder fails via NewPublishPaths
+  - new_publish_paths op is preserved
+*/
+func TestNewConfigurePathsRejectsInvalidSubjectBuilder(t *testing.T) {
+	_, err := NewConfigurePaths(&stubDesiredConfigStore{}, &stubPublisher{}, nil, agentcore.KVConfig{}, nil)
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "new_publish_paths", "subject builder is required")
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-005
+Type: Negative
+Title: SubmitConfigure rejects invalid configure command before store
+Summary:
+Verifies that configure submit performs transport validation first and does not
+attempt KV store or notify publish when the command is invalid.
+
+Validates:
+  - invalid configure command returns CodeValidation
+  - store and publish are not called on validation failure
+*/
+func TestSubmitConfigureRejectsInvalidCommandBeforeStore(t *testing.T) {
+	store := &stubDesiredConfigStore{}
+	pub := &stubPublisher{}
+
+	paths, err := NewConfigurePaths(store, pub, subjects.NewDefaultBuilder(), agentcore.KVConfig{}, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	cmd := validTransportConfigureCommand()
+	cmd.UUID = ""
+
+	ack, err := paths.SubmitConfigure(context.Background(), cmd)
+	if ack != nil {
+		t.Fatalf("expected nil ack, got %#v", ack)
+	}
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "validate_configure_command", "uuid is required")
+	if len(store.calls) != 0 {
+		t.Fatalf("expected store not to be called, got %d calls", len(store.calls))
+	}
+	if len(pub.calls) != 0 {
+		t.Fatalf("expected publish not to be called, got %d calls", len(pub.calls))
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-006
+Type: Negative
+Title: SubmitConfigure wraps store failure and skips notify publish
+Summary:
+Verifies that configure submit wraps KV store failures with store-specific typed
+errors and does not publish configure notification when store fails.
+
+Validates:
+  - store failure returns CodeKVStoreFailed
+  - notify publish does not happen when store fails
+*/
+func TestSubmitConfigureWrapsStoreFailureAndSkipsNotify(t *testing.T) {
+	store := &stubDesiredConfigStore{err: errors.New("kv unavailable")}
+	pub := &stubPublisher{}
+
+	paths, err := NewConfigurePaths(store, pub, subjects.NewDefaultBuilder(), agentcore.KVConfig{}, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	ack, err := paths.SubmitConfigure(context.Background(), validTransportConfigureCommand())
+	if ack != nil {
+		t.Fatalf("expected nil ack, got %#v", ack)
+	}
+	requireTransportAgentcoreError(t, err, agentcore.CodeKVStoreFailed, "submit_configure_store", "failed to store desired config")
+	if len(pub.calls) != 0 {
+		t.Fatalf("expected publish not to be called, got %d calls", len(pub.calls))
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-007
+Type: Negative
+Title: SubmitConfigure rejects nil store result and skips notify publish
+Summary:
+Verifies that configure submit rejects a nil stored record result from the KV
+store dependency and does not publish notification.
+
+Validates:
+  - nil stored result returns CodeKVStoreFailed
+  - notify publish is not attempted
+*/
+func TestSubmitConfigureRejectsNilStoredResultAndSkipsNotify(t *testing.T) {
+	store := &stubDesiredConfigStore{result: nil}
+	pub := &stubPublisher{}
+
+	paths, err := NewConfigurePaths(store, pub, subjects.NewDefaultBuilder(), agentcore.KVConfig{}, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	ack, err := paths.SubmitConfigure(context.Background(), validTransportConfigureCommand())
+	if ack != nil {
+		t.Fatalf("expected nil ack, got %#v", ack)
+	}
+	requireTransportAgentcoreError(t, err, agentcore.CodeKVStoreFailed, "submit_configure_store", "desired config store returned nil result")
+	if len(pub.calls) != 0 {
+		t.Fatalf("expected publish not to be called, got %d calls", len(pub.calls))
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-008
+Type: Positive
+Title: SubmitConfigure uses stored bucket and key when provided
+Summary:
+Verifies that configure submit prefers bucket and key returned by the store and
+publishes notification plus ack using those stored values.
+
+Validates:
+  - stored bucket and key are used in notification and ack
+  - returned ack includes revision and configure subject
+*/
+func TestSubmitConfigureUsesStoredBucketAndKeyWhenProvided(t *testing.T) {
+	fixedNow := transportTestTime().Add(15 * time.Minute)
+	store := &stubDesiredConfigStore{
+		result: &agentcore.StoredDesiredConfig{
+			Record:    agentcore.DesiredConfigRecord{},
+			Bucket:    "stored_bucket",
+			Key:       "stored.key",
+			Revision:  42,
+			CreatedAt: transportTestTime(),
+		},
+	}
+	pub := &stubPublisher{}
+
+	paths, err := NewConfigurePaths(store, pub, subjects.NewDefaultBuilder(), agentcore.KVConfig{}, func() time.Time { return fixedNow })
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	cmd := validTransportConfigureCommand()
+	ack, err := paths.SubmitConfigure(context.Background(), cmd)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if ack == nil {
+		t.Fatal("expected non-nil ack")
+	}
+	if ack.Subject != "cmd.configure.vyos" {
+		t.Fatalf("expected ack subject %q, got %q", "cmd.configure.vyos", ack.Subject)
+	}
+	if ack.KVBucket != "stored_bucket" {
+		t.Fatalf("expected ack KVBucket %q, got %q", "stored_bucket", ack.KVBucket)
+	}
+	if ack.KVKey != "stored.key" {
+		t.Fatalf("expected ack KVKey %q, got %q", "stored.key", ack.KVKey)
+	}
+	if ack.KVRevision != 42 {
+		t.Fatalf("expected ack KVRevision %d, got %d", 42, ack.KVRevision)
+	}
+	if !ack.AcceptedAt.Equal(fixedNow) {
+		t.Fatalf("expected ack AcceptedAt %v, got %v", fixedNow, ack.AcceptedAt)
+	}
+
+	if len(store.calls) != 1 {
+		t.Fatalf("expected one store call, got %d", len(store.calls))
+	}
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected one publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].subject != "cmd.configure.vyos" {
+		t.Fatalf("expected publish subject %q, got %q", "cmd.configure.vyos", pub.calls[0].subject)
+	}
+
+	notification, err := contract.DecodeConfigureNotification(pub.calls[0].payload)
+	if err != nil {
+		t.Fatalf("expected decodable configure notification payload, got %v", err)
+	}
+	if notification.KVBucket != "stored_bucket" {
+		t.Fatalf("expected notification KVBucket %q, got %q", "stored_bucket", notification.KVBucket)
+	}
+	if notification.KVKey != "stored.key" {
+		t.Fatalf("expected notification KVKey %q, got %q", "stored.key", notification.KVKey)
+	}
+	if notification.CommandType != "configure" {
+		t.Fatalf("expected notification CommandType %q, got %q", "configure", notification.CommandType)
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-009
+Type: Positive
+Title: SubmitConfigure falls back to configured default bucket and key pattern
+Summary:
+Verifies that configure submit generates fallback bucket and key when store
+result does not include bucket and key values.
+
+Validates:
+  - default bucket and generated key are used in notification and ack
+  - fallback key follows configured key pattern
+*/
+func TestSubmitConfigureFallsBackToDefaultBucketAndGeneratedKey(t *testing.T) {
+	store := &stubDesiredConfigStore{
+		result: &agentcore.StoredDesiredConfig{
+			Record:    agentcore.DesiredConfigRecord{},
+			Bucket:    "",
+			Key:       "",
+			Revision:  7,
+			CreatedAt: transportTestTime(),
+		},
+	}
+	pub := &stubPublisher{}
+
+	paths, err := NewConfigurePaths(
+		store,
+		pub,
+		subjects.NewDefaultBuilder(),
+		agentcore.KVConfig{Bucket: "cfg_custom", KeyPattern: "desired.custom.%s"},
+		func() time.Time { return transportTestTime() },
+	)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	ack, err := paths.SubmitConfigure(context.Background(), validTransportConfigureCommand())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if ack.KVBucket != "cfg_custom" {
+		t.Fatalf("expected ack KVBucket %q, got %q", "cfg_custom", ack.KVBucket)
+	}
+	if ack.KVKey != "desired.custom.vyos" {
+		t.Fatalf("expected ack KVKey %q, got %q", "desired.custom.vyos", ack.KVKey)
+	}
+
+	notification, err := contract.DecodeConfigureNotification(pub.calls[0].payload)
+	if err != nil {
+		t.Fatalf("expected decodable configure notification payload, got %v", err)
+	}
+	if notification.KVBucket != "cfg_custom" {
+		t.Fatalf("expected notification KVBucket %q, got %q", "cfg_custom", notification.KVBucket)
+	}
+	if notification.KVKey != "desired.custom.vyos" {
+		t.Fatalf("expected notification KVKey %q, got %q", "desired.custom.vyos", notification.KVKey)
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-010
+Type: Negative
+Title: SubmitConfigure fails when fallback key pattern is invalid
+Summary:
+Verifies that configure submit returns key-pattern validation errors when it
+must generate a fallback key from an invalid configured pattern.
+
+Validates:
+  - invalid key pattern returns CodeValidation
+  - notify publish is not attempted when key generation fails
+*/
+func TestSubmitConfigureFailsWhenFallbackKeyPatternIsInvalid(t *testing.T) {
+	store := &stubDesiredConfigStore{
+		result: &agentcore.StoredDesiredConfig{
+			Record:    agentcore.DesiredConfigRecord{},
+			Bucket:    "",
+			Key:       "",
+			Revision:  1,
+			CreatedAt: transportTestTime(),
+		},
+	}
+	pub := &stubPublisher{}
+
+	paths, err := NewConfigurePaths(
+		store,
+		pub,
+		subjects.NewDefaultBuilder(),
+		agentcore.KVConfig{Bucket: "cfg_desired", KeyPattern: "desired.%s.%d"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	ack, err := paths.SubmitConfigure(context.Background(), validTransportConfigureCommand())
+	if ack != nil {
+		t.Fatalf("expected nil ack, got %#v", ack)
+	}
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "build_kv_key", "kv key pattern contains unsupported format directives")
+	if len(pub.calls) != 0 {
+		t.Fatalf("expected publish not to be called, got %d calls", len(pub.calls))
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-011
+Type: Positive
+Title: SubmitConfigure performs store before notify publish
+Summary:
+Verifies that configure flow execution preserves store-then-notify ordering by
+calling the store before any notification publish.
+
+Validates:
+  - store call happens before publish call
+  - both steps run on successful configure submit
+*/
+func TestSubmitConfigurePerformsStoreBeforeNotifyPublish(t *testing.T) {
+	order := make([]string, 0, 2)
+	store := &stubDesiredConfigStore{
+		result: &agentcore.StoredDesiredConfig{
+			Record:    agentcore.DesiredConfigRecord{},
+			Bucket:    "cfg_desired",
+			Key:       "desired.vyos",
+			Revision:  9,
+			CreatedAt: transportTestTime(),
+		},
+		onStore: func(_ agentcore.DesiredConfigRecord) {
+			order = append(order, "store")
+		},
+	}
+	pub := &stubPublisher{
+		onPublish: func(_ string, _ []byte) {
+			order = append(order, "publish")
+		},
+	}
+
+	paths, err := NewConfigurePaths(store, pub, subjects.NewDefaultBuilder(), agentcore.KVConfig{}, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	_, err = paths.SubmitConfigure(context.Background(), validTransportConfigureCommand())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(order) != 2 {
+		t.Fatalf("expected call order length 2, got %d", len(order))
+	}
+	if order[0] != "store" || order[1] != "publish" {
+		t.Fatalf("expected call order [store publish], got %v", order)
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-012
+Type: Positive
+Title: buildKVKey builds key for valid pattern and target
+Summary:
+Verifies that KV key builder produces expected key output when given a valid
+pattern and valid target token.
+
+Validates:
+  - desired.<target> key is produced for default pattern
+*/
+func TestBuildKVKeyBuildsKeyForValidPatternAndTarget(t *testing.T) {
+	key, err := buildKVKey("desired.%s", "vyos")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if key != "desired.vyos" {
+		t.Fatalf("expected key %q, got %q", "desired.vyos", key)
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-013
+Type: Negative
+Title: buildKVKey rejects invalid pattern and target inputs
+Summary:
+Verifies that KV key builder rejects malformed patterns and invalid targets
+before returning any key.
+
+Validates:
+  - empty pattern placeholder mismatch and unsupported directives fail
+  - invalid target fails via target validator
+*/
+func TestBuildKVKeyRejectsInvalidPatternAndTargetInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		target  string
+		wantOp  string
+		msgPart string
+	}{
+		{
+			name:    "empty pattern",
+			pattern: "  ",
+			target:  "vyos",
+			wantOp:  "build_kv_key",
+			msgPart: "kv key pattern is required",
+		},
+		{
+			name:    "pattern contains whitespace",
+			pattern: "desired. %s",
+			target:  "vyos",
+			wantOp:  "build_kv_key",
+			msgPart: "kv key pattern cannot contain whitespace",
+		},
+		{
+			name:    "placeholder mismatch",
+			pattern: "desired.key",
+			target:  "vyos",
+			wantOp:  "build_kv_key",
+			msgPart: "kv key pattern must contain exactly one %s placeholder",
+		},
+		{
+			name:    "unsupported format directive",
+			pattern: "desired.%s.%d",
+			target:  "vyos",
+			wantOp:  "build_kv_key",
+			msgPart: "kv key pattern contains unsupported format directives",
+		},
+		{
+			name:    "invalid target",
+			pattern: "desired.%s",
+			target:  "vyos core",
+			wantOp:  "validate_target",
+			msgPart: "target cannot contain whitespace",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildKVKey(tc.pattern, tc.target)
+			requireTransportAgentcoreError(t, err, agentcore.CodeValidation, tc.wantOp, tc.msgPart)
+		})
+	}
+}
+
+/*
+TC-TRANSPORT-CONFIGURE-014
+Type: Negative
+Title: SubmitConfigure returns publish failure after successful store
+Summary:
+Verifies that configure submit returns a publish failure when notify publish
+fails after a successful store, while keeping store side effects intact.
+
+Validates:
+  - publish failure returns CodePublishFailed with publish op context
+  - ack is nil when notify publish fails
+  - store is called exactly once before publish failure is returned
+*/
+func TestSubmitConfigureReturnsPublishFailureAfterSuccessfulStore(t *testing.T) {
+	order := make([]string, 0, 2)
+	store := &stubDesiredConfigStore{
+		result: &agentcore.StoredDesiredConfig{
+			Record:    agentcore.DesiredConfigRecord{},
+			Bucket:    "cfg_desired",
+			Key:       "desired.vyos",
+			Revision:  11,
+			CreatedAt: transportTestTime(),
+		},
+		onStore: func(_ agentcore.DesiredConfigRecord) {
+			order = append(order, "store")
+		},
+	}
+
+	publishCause := errors.New("notify publish failed")
+	pub := &stubPublisher{
+		err: publishCause,
+		onPublish: func(_ string, _ []byte) {
+			order = append(order, "publish")
+		},
+	}
+
+	paths, err := NewConfigurePaths(store, pub, subjects.NewDefaultBuilder(), agentcore.KVConfig{}, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	ack, err := paths.SubmitConfigure(context.Background(), validTransportConfigureCommand())
+	if ack != nil {
+		t.Fatalf("expected nil ack, got %#v", ack)
+	}
+
+	got := requireTransportAgentcoreError(t, err, agentcore.CodePublishFailed, "publish_configure_notification", "publish failed")
+	if got.Op == "submit_configure_store" {
+		t.Fatal("expected publish failure to not be reported as store failure")
+	}
+	if !errors.Is(got, publishCause) {
+		t.Fatal("expected wrapped publish cause to be reachable via errors.Is")
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("expected exactly one store call, got %d", len(store.calls))
+	}
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected exactly one publish call, got %d", len(pub.calls))
+	}
+	if len(order) != 2 || order[0] != "store" || order[1] != "publish" {
+		t.Fatalf("expected call order [store publish], got %v", order)
+	}
+}

--- a/internal/transport/publish.go
+++ b/internal/transport/publish.go
@@ -1,0 +1,118 @@
+package transport
+
+import (
+	"context"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+	"github.com/routerarchitects/nats-agent-core/internal/contract"
+	"github.com/routerarchitects/nats-agent-core/internal/subjects"
+)
+
+// Publisher is the shared publish dependency used by transport wrappers.
+type Publisher interface {
+	Publish(ctx context.Context, subject string, payload []byte) error
+}
+
+// PublishPaths centralizes publish wrappers for shared message types.
+type PublishPaths struct {
+	subjects *subjects.Builder
+}
+
+// NewPublishPaths creates publish wrappers with a validated subject builder.
+func NewPublishPaths(builder *subjects.Builder) (*PublishPaths, error) {
+	if builder == nil {
+		return nil, &agentcore.Error{
+			Code:      agentcore.CodeValidation,
+			Op:        "new_publish_paths",
+			Message:   "subject builder is required",
+			Retryable: false,
+		}
+	}
+	return &PublishPaths{subjects: builder}, nil
+}
+
+// PublishConfigureNotification publishes a lightweight configure notification.
+func (p *PublishPaths) PublishConfigureNotification(ctx context.Context, publisher Publisher, msg agentcore.ConfigureNotification) error {
+	subject, err := p.subjects.ConfigureSubject(msg.Target)
+	if err != nil {
+		return err
+	}
+	payload, err := contract.EncodeConfigureNotification(msg)
+	if err != nil {
+		return err
+	}
+	return publishEncoded(ctx, publisher, "publish_configure_notification", subject, payload)
+}
+
+// SubmitAction publishes an action command on the centralized action subject path.
+func (p *PublishPaths) SubmitAction(ctx context.Context, publisher Publisher, cmd agentcore.ActionCommand) (*agentcore.SubmissionAck, error) {
+	subject, err := p.subjects.ActionSubject(cmd.Target, cmd.Action)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := contract.EncodeActionCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if err := publishEncoded(ctx, publisher, "submit_action_publish", subject, payload); err != nil {
+		return nil, err
+	}
+
+	return &agentcore.SubmissionAck{
+		Accepted:   true,
+		RPCID:      cmd.RPCID,
+		Target:     cmd.Target,
+		Subject:    subject,
+		AcceptedAt: cmd.Timestamp,
+	}, nil
+}
+
+// PublishResult publishes a result envelope through the shared result path.
+func (p *PublishPaths) PublishResult(ctx context.Context, publisher Publisher, msg agentcore.ResultEnvelope) error {
+	subject, err := p.subjects.ResultSubject(msg.Target)
+	if err != nil {
+		return err
+	}
+	payload, err := contract.EncodeResultEnvelope(msg)
+	if err != nil {
+		return err
+	}
+	return publishEncoded(ctx, publisher, "publish_result", subject, payload)
+}
+
+// PublishStatus publishes a status envelope through the shared status path.
+func (p *PublishPaths) PublishStatus(ctx context.Context, publisher Publisher, msg agentcore.StatusEnvelope) error {
+	subject, err := p.subjects.StatusSubject(msg.Target)
+	if err != nil {
+		return err
+	}
+	payload, err := contract.EncodeStatusEnvelope(msg)
+	if err != nil {
+		return err
+	}
+	return publishEncoded(ctx, publisher, "publish_status", subject, payload)
+}
+
+func publishEncoded(ctx context.Context, publisher Publisher, op, subject string, payload []byte) error {
+	if publisher == nil {
+		return &agentcore.Error{
+			Code:      agentcore.CodeValidation,
+			Op:        op,
+			Subject:   subject,
+			Message:   "publisher is required",
+			Retryable: false,
+		}
+	}
+	if err := publisher.Publish(ctx, subject, payload); err != nil {
+		return &agentcore.Error{
+			Code:      agentcore.CodePublishFailed,
+			Op:        op,
+			Subject:   subject,
+			Message:   "publish failed",
+			Retryable: true,
+			Err:       err,
+		}
+	}
+	return nil
+}
+

--- a/internal/transport/publish.go
+++ b/internal/transport/publish.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"time"
 
 	"github.com/routerarchitects/nats-agent-core/agentcore"
 	"github.com/routerarchitects/nats-agent-core/internal/contract"
@@ -16,6 +17,7 @@ type Publisher interface {
 // PublishPaths centralizes publish wrappers for shared message types.
 type PublishPaths struct {
 	subjects *subjects.Builder
+	now      func() time.Time
 }
 
 // NewPublishPaths creates publish wrappers with a validated subject builder.
@@ -28,7 +30,10 @@ func NewPublishPaths(builder *subjects.Builder) (*PublishPaths, error) {
 			Retryable: false,
 		}
 	}
-	return &PublishPaths{subjects: builder}, nil
+	return &PublishPaths{
+		subjects: builder,
+		now:      time.Now,
+	}, nil
 }
 
 // PublishConfigureNotification publishes a lightweight configure notification.
@@ -58,12 +63,17 @@ func (p *PublishPaths) SubmitAction(ctx context.Context, publisher Publisher, cm
 		return nil, err
 	}
 
+	acceptedAt := time.Now()
+	if p.now != nil {
+		acceptedAt = p.now()
+	}
+
 	return &agentcore.SubmissionAck{
 		Accepted:   true,
 		RPCID:      cmd.RPCID,
 		Target:     cmd.Target,
 		Subject:    subject,
-		AcceptedAt: cmd.Timestamp,
+		AcceptedAt: acceptedAt,
 	}, nil
 }
 
@@ -115,4 +125,3 @@ func publishEncoded(ctx context.Context, publisher Publisher, op, subject string
 	}
 	return nil
 }
-

--- a/internal/transport/publish_test.go
+++ b/internal/transport/publish_test.go
@@ -1,0 +1,648 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/routerarchitects/nats-agent-core/agentcore"
+	"github.com/routerarchitects/nats-agent-core/internal/contract"
+	"github.com/routerarchitects/nats-agent-core/internal/subjects"
+)
+
+type publishCall struct {
+	subject string
+	payload []byte
+}
+
+type stubPublisher struct {
+	calls     []publishCall
+	err       error
+	onPublish func(subject string, payload []byte)
+}
+
+func (p *stubPublisher) Publish(_ context.Context, subject string, payload []byte) error {
+	copied := append([]byte(nil), payload...)
+	p.calls = append(p.calls, publishCall{subject: subject, payload: copied})
+	if p.onPublish != nil {
+		p.onPublish(subject, copied)
+	}
+	return p.err
+}
+
+func transportTestTime() time.Time {
+	return time.Unix(1700000000, 0).UTC()
+}
+
+func transportRawJSON(s string) json.RawMessage {
+	return json.RawMessage(s)
+}
+
+func validTransportConfigureNotification() agentcore.ConfigureNotification {
+	return agentcore.ConfigureNotification{
+		Version:     "1.0",
+		RPCID:       "rpc-notify-1",
+		Target:      "vyos",
+		CommandType: "configure",
+		UUID:        "cfg-001",
+		KVBucket:    "cfg_desired",
+		KVKey:       "desired.vyos",
+		Timestamp:   transportTestTime(),
+	}
+}
+
+func validTransportActionCommand() agentcore.ActionCommand {
+	return agentcore.ActionCommand{
+		Version:     "1.0",
+		RPCID:       "rpc-action-1",
+		Target:      "vyos",
+		CommandType: "action",
+		Action:      "trace",
+		Payload:     transportRawJSON(`{"destination":"8.8.8.8"}`),
+		Timestamp:   transportTestTime(),
+	}
+}
+
+func validTransportResultEnvelope() agentcore.ResultEnvelope {
+	return agentcore.ResultEnvelope{
+		Version:   "1.0",
+		RPCID:     "rpc-result-1",
+		Target:    "vyos",
+		Result:    "success",
+		Message:   "ok",
+		Payload:   transportRawJSON(`{"applied":true}`),
+		Timestamp: transportTestTime(),
+	}
+}
+
+func validTransportStatusEnvelope() agentcore.StatusEnvelope {
+	return agentcore.StatusEnvelope{
+		Version:   "1.0",
+		Target:    "vyos",
+		Status:    "running",
+		Message:   "ready",
+		Payload:   transportRawJSON(`{"ready":true}`),
+		Timestamp: transportTestTime(),
+	}
+}
+
+func requireTransportAgentcoreError(t *testing.T, err error, wantCode agentcore.Code, wantOp string, wantMsgPart string) *agentcore.Error {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+
+	var got *agentcore.Error
+	if !errors.As(err, &got) {
+		t.Fatalf("expected *agentcore.Error, got %T", err)
+	}
+	if got.Code != wantCode {
+		t.Fatalf("expected error code %q, got %q", wantCode, got.Code)
+	}
+	if got.Op != wantOp {
+		t.Fatalf("expected error op %q, got %q", wantOp, got.Op)
+	}
+	if wantMsgPart != "" && !strings.Contains(got.Message, wantMsgPart) {
+		t.Fatalf("expected error message to contain %q, got %q", wantMsgPart, got.Message)
+	}
+	return got
+}
+
+/*
+TC-TRANSPORT-PUBLISH-001
+Type: Positive
+Title: NewPublishPaths accepts a valid subject builder
+Summary:
+Verifies that publish path construction succeeds with a valid builder and
+initializes internal dependencies for publish helpers.
+
+Validates:
+  - non-nil publish paths are returned
+  - internal clock source is initialized
+*/
+func TestNewPublishPathsAcceptsValidBuilder(t *testing.T) {
+	builder := subjects.NewDefaultBuilder()
+
+	paths, err := NewPublishPaths(builder)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if paths == nil {
+		t.Fatal("expected non-nil publish paths")
+	}
+	if paths.now == nil {
+		t.Fatal("expected publish paths clock to be initialized")
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-002
+Type: Negative
+Title: NewPublishPaths rejects nil builder
+Summary:
+Verifies that publish path construction fails fast when subject builder
+dependency is missing.
+
+Validates:
+  - nil builder returns CodeValidation
+  - error op is new_publish_paths
+*/
+func TestNewPublishPathsRejectsNilBuilder(t *testing.T) {
+	_, err := NewPublishPaths(nil)
+
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "new_publish_paths", "subject builder is required")
+}
+
+/*
+TC-TRANSPORT-PUBLISH-003
+Type: Positive
+Title: PublishConfigureNotification publishes encoded notification on configure subject
+Summary:
+Verifies that configure notification publish uses the configured subject helper
+and sends an encoded notification payload.
+
+Validates:
+  - publish uses cmd.configure.<target> subject
+  - payload decodes as ConfigureNotification with preserved fields
+*/
+func TestPublishConfigureNotificationPublishesEncodedNotification(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	msg := validTransportConfigureNotification()
+	pub := &stubPublisher{}
+
+	err = paths.PublishConfigureNotification(context.Background(), pub, msg)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected one publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].subject != "cmd.configure.vyos" {
+		t.Fatalf("expected subject %q, got %q", "cmd.configure.vyos", pub.calls[0].subject)
+	}
+
+	decoded, err := contract.DecodeConfigureNotification(pub.calls[0].payload)
+	if err != nil {
+		t.Fatalf("expected decodable configure notification payload, got %v", err)
+	}
+	if decoded.RPCID != msg.RPCID {
+		t.Fatalf("expected RPCID %q, got %q", msg.RPCID, decoded.RPCID)
+	}
+	if decoded.KVBucket != msg.KVBucket {
+		t.Fatalf("expected KVBucket %q, got %q", msg.KVBucket, decoded.KVBucket)
+	}
+	if decoded.KVKey != msg.KVKey {
+		t.Fatalf("expected KVKey %q, got %q", msg.KVKey, decoded.KVKey)
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-004
+Type: Negative
+Title: PublishConfigureNotification rejects nil publisher
+Summary:
+Verifies that configure notification publish returns a validation error when
+publisher dependency is missing.
+
+Validates:
+  - nil publisher returns CodeValidation
+  - error op is publish_configure_notification
+*/
+func TestPublishConfigureNotificationRejectsNilPublisher(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	err = paths.PublishConfigureNotification(context.Background(), nil, validTransportConfigureNotification())
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "publish_configure_notification", "publisher is required")
+}
+
+/*
+TC-TRANSPORT-PUBLISH-005
+Type: Negative
+Title: PublishConfigureNotification wraps publisher failure
+Summary:
+Verifies that configure notification publish wraps low-level publisher failures
+as typed publish errors.
+
+Validates:
+  - publisher failure returns CodePublishFailed
+  - wrapped cause is preserved for error inspection
+*/
+func TestPublishConfigureNotificationWrapsPublisherFailure(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	cause := errors.New("write timeout")
+	pub := &stubPublisher{err: cause}
+
+	err = paths.PublishConfigureNotification(context.Background(), pub, validTransportConfigureNotification())
+	got := requireTransportAgentcoreError(t, err, agentcore.CodePublishFailed, "publish_configure_notification", "publish failed")
+	if !errors.Is(got, cause) {
+		t.Fatal("expected wrapped publish cause to be reachable via errors.Is")
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-006
+Type: Positive
+Title: SubmitAction publishes command and returns submission ack
+Summary:
+Verifies that action submit publishes the encoded action command and returns a
+successful submission ack with shared correlation fields.
+
+Validates:
+  - action publish uses cmd.action.<target>.<action> subject
+  - submission ack contains accepted fields and internal AcceptedAt time
+  - published payload decodes as ActionCommand
+*/
+func TestSubmitActionPublishesCommandAndReturnsSubmissionAck(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	ackTime := transportTestTime().Add(5 * time.Minute)
+	paths.now = func() time.Time { return ackTime }
+
+	cmd := validTransportActionCommand()
+	cmd.Timestamp = transportTestTime().Add(-1 * time.Hour)
+
+	pub := &stubPublisher{}
+
+	ack, err := paths.SubmitAction(context.Background(), pub, cmd)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if ack == nil {
+		t.Fatal("expected non-nil submission ack")
+	}
+	if !ack.Accepted {
+		t.Fatal("expected ack Accepted=true")
+	}
+	if ack.RPCID != cmd.RPCID {
+		t.Fatalf("expected ack RPCID %q, got %q", cmd.RPCID, ack.RPCID)
+	}
+	if ack.Target != cmd.Target {
+		t.Fatalf("expected ack Target %q, got %q", cmd.Target, ack.Target)
+	}
+	if ack.Subject != "cmd.action.vyos.trace" {
+		t.Fatalf("expected ack Subject %q, got %q", "cmd.action.vyos.trace", ack.Subject)
+	}
+	if !ack.AcceptedAt.Equal(ackTime) {
+		t.Fatalf("expected ack AcceptedAt %v, got %v", ackTime, ack.AcceptedAt)
+	}
+	if ack.AcceptedAt.Equal(cmd.Timestamp) {
+		t.Fatal("expected AcceptedAt to use internal clock, not command timestamp")
+	}
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected one publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].subject != "cmd.action.vyos.trace" {
+		t.Fatalf("expected subject %q, got %q", "cmd.action.vyos.trace", pub.calls[0].subject)
+	}
+
+	decoded, err := contract.DecodeActionCommand(pub.calls[0].payload)
+	if err != nil {
+		t.Fatalf("expected decodable action payload, got %v", err)
+	}
+	if decoded.Action != cmd.Action {
+		t.Fatalf("expected Action %q, got %q", cmd.Action, decoded.Action)
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-007
+Type: Negative
+Title: SubmitAction wraps publish failure
+Summary:
+Verifies that action submit returns a typed publish failure and no successful
+ack when the publisher returns an error.
+
+Validates:
+  - publish error returns CodePublishFailed
+  - submit_action_publish op is preserved
+*/
+func TestSubmitActionWrapsPublishFailure(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	pub := &stubPublisher{err: errors.New("nats unavailable")}
+
+	ack, err := paths.SubmitAction(context.Background(), pub, validTransportActionCommand())
+	if ack != nil {
+		t.Fatalf("expected nil ack, got %#v", ack)
+	}
+	requireTransportAgentcoreError(t, err, agentcore.CodePublishFailed, "submit_action_publish", "publish failed")
+}
+
+/*
+TC-TRANSPORT-PUBLISH-008
+Type: Positive
+Title: PublishResult publishes encoded result envelope
+Summary:
+Verifies that result publish uses the result subject helper and sends an
+encoded result envelope payload.
+
+Validates:
+  - publish uses result.<target> subject
+  - payload decodes as ResultEnvelope
+*/
+func TestPublishResultPublishesEncodedResultEnvelope(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	msg := validTransportResultEnvelope()
+	pub := &stubPublisher{}
+
+	err = paths.PublishResult(context.Background(), pub, msg)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected one publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].subject != "result.vyos" {
+		t.Fatalf("expected subject %q, got %q", "result.vyos", pub.calls[0].subject)
+	}
+
+	decoded, err := contract.DecodeResultEnvelope(pub.calls[0].payload)
+	if err != nil {
+		t.Fatalf("expected decodable result payload, got %v", err)
+	}
+	if decoded.Result != msg.Result {
+		t.Fatalf("expected Result %q, got %q", msg.Result, decoded.Result)
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-009
+Type: Positive
+Title: PublishStatus publishes encoded status envelope
+Summary:
+Verifies that status publish uses the status subject helper and sends an
+encoded status envelope payload.
+
+Validates:
+  - publish uses status.<target> subject
+  - payload decodes as StatusEnvelope
+*/
+func TestPublishStatusPublishesEncodedStatusEnvelope(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	msg := validTransportStatusEnvelope()
+	pub := &stubPublisher{}
+
+	err = paths.PublishStatus(context.Background(), pub, msg)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected one publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].subject != "status.vyos" {
+		t.Fatalf("expected subject %q, got %q", "status.vyos", pub.calls[0].subject)
+	}
+
+	decoded, err := contract.DecodeStatusEnvelope(pub.calls[0].payload)
+	if err != nil {
+		t.Fatalf("expected decodable status payload, got %v", err)
+	}
+	if decoded.Status != msg.Status {
+		t.Fatalf("expected Status %q, got %q", msg.Status, decoded.Status)
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-010
+Type: Negative
+Title: publishEncoded rejects nil publisher
+Summary:
+Verifies that the shared publish helper rejects nil publisher dependency before
+attempting to publish.
+
+Validates:
+  - nil publisher returns CodeValidation
+  - helper op and subject are preserved in the error
+*/
+func TestPublishEncodedRejectsNilPublisher(t *testing.T) {
+	err := publishEncoded(context.Background(), nil, "publish_result", "result.vyos", []byte(`{}`))
+	got := requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "publish_result", "publisher is required")
+	if got.Subject != "result.vyos" {
+		t.Fatalf("expected subject %q, got %q", "result.vyos", got.Subject)
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-011
+Type: Negative
+Title: publishEncoded wraps publisher failure
+Summary:
+Verifies that the shared publish helper wraps publisher failures with publish
+error semantics used by higher-level wrappers.
+
+Validates:
+  - publisher failure returns CodePublishFailed
+  - wrapped cause remains accessible
+*/
+func TestPublishEncodedWrapsPublisherFailure(t *testing.T) {
+	cause := errors.New("publish failed")
+	pub := &stubPublisher{err: cause}
+
+	err := publishEncoded(context.Background(), pub, "publish_result", "result.vyos", []byte(`{}`))
+	got := requireTransportAgentcoreError(t, err, agentcore.CodePublishFailed, "publish_result", "publish failed")
+	if !errors.Is(got, cause) {
+		t.Fatal("expected wrapped publish cause to be reachable via errors.Is")
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-012
+Type: Negative
+Title: SubmitAction rejects invalid target and action before publish
+Summary:
+Verifies that action submit validates subject inputs before attempting publish
+and returns validation failures for malformed target or action tokens.
+
+Validates:
+  - invalid target returns validate_target error
+  - invalid action returns validate_action error
+  - publish side effect is skipped on validation failures
+*/
+func TestSubmitActionRejectsInvalidTargetAndActionBeforePublish(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*agentcore.ActionCommand)
+		wantOp  string
+		msgPart string
+	}{
+		{
+			name: "invalid target",
+			mutate: func(cmd *agentcore.ActionCommand) {
+				cmd.Target = "vyos core"
+			},
+			wantOp:  "validate_target",
+			msgPart: "target cannot contain whitespace",
+		},
+		{
+			name: "invalid action",
+			mutate: func(cmd *agentcore.ActionCommand) {
+				cmd.Action = "trace now"
+			},
+			wantOp:  "validate_action",
+			msgPart: "action cannot contain whitespace",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := validTransportActionCommand()
+			tc.mutate(&cmd)
+
+			pub := &stubPublisher{}
+			ack, err := paths.SubmitAction(context.Background(), pub, cmd)
+			if ack != nil {
+				t.Fatalf("expected nil ack, got %#v", ack)
+			}
+			requireTransportAgentcoreError(t, err, agentcore.CodeValidation, tc.wantOp, tc.msgPart)
+			if len(pub.calls) != 0 {
+				t.Fatalf("expected publish not to be called, got %d calls", len(pub.calls))
+			}
+		})
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-013
+Type: Negative
+Title: PublishResult rejects invalid target before publish
+Summary:
+Verifies that result publish validates target before encoding and publishing.
+
+Validates:
+  - invalid target returns validate_target error
+  - publish side effect is skipped
+*/
+func TestPublishResultRejectsInvalidTargetBeforePublish(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	msg := validTransportResultEnvelope()
+	msg.Target = "vyos core"
+	pub := &stubPublisher{}
+
+	err = paths.PublishResult(context.Background(), pub, msg)
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "validate_target", "target cannot contain whitespace")
+	if len(pub.calls) != 0 {
+		t.Fatalf("expected publish not to be called, got %d calls", len(pub.calls))
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-014
+Type: Negative
+Title: PublishStatus rejects invalid target before publish
+Summary:
+Verifies that status publish validates target before encoding and publishing.
+
+Validates:
+  - invalid target returns validate_target error
+  - publish side effect is skipped
+*/
+func TestPublishStatusRejectsInvalidTargetBeforePublish(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	msg := validTransportStatusEnvelope()
+	msg.Target = "vyos core"
+	pub := &stubPublisher{}
+
+	err = paths.PublishStatus(context.Background(), pub, msg)
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "validate_target", "target cannot contain whitespace")
+	if len(pub.calls) != 0 {
+		t.Fatalf("expected publish not to be called, got %d calls", len(pub.calls))
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-015
+Type: Negative
+Title: PublishResult wraps publisher failure
+Summary:
+Verifies that result publish wraps low-level publisher failures using the
+publish_result operation context.
+
+Validates:
+  - publish failure returns CodePublishFailed
+  - wrapped cause is preserved
+*/
+func TestPublishResultWrapsPublisherFailure(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	cause := errors.New("publish result failed")
+	pub := &stubPublisher{err: cause}
+
+	err = paths.PublishResult(context.Background(), pub, validTransportResultEnvelope())
+	got := requireTransportAgentcoreError(t, err, agentcore.CodePublishFailed, "publish_result", "publish failed")
+	if !errors.Is(got, cause) {
+		t.Fatal("expected wrapped publish cause to be reachable via errors.Is")
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-016
+Type: Negative
+Title: PublishStatus wraps publisher failure
+Summary:
+Verifies that status publish wraps low-level publisher failures using the
+publish_status operation context.
+
+Validates:
+  - publish failure returns CodePublishFailed
+  - wrapped cause is preserved
+*/
+func TestPublishStatusWrapsPublisherFailure(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	cause := errors.New("publish status failed")
+	pub := &stubPublisher{err: cause}
+
+	err = paths.PublishStatus(context.Background(), pub, validTransportStatusEnvelope())
+	got := requireTransportAgentcoreError(t, err, agentcore.CodePublishFailed, "publish_status", "publish failed")
+	if !errors.Is(got, cause) {
+		t.Fatal("expected wrapped publish cause to be reachable via errors.Is")
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements internal Phase 3 messaging foundations for nats-agent-core.

It adds:
- centralized subject helpers for configure, action, result, and status
- shared validation for malformed target/action routing inputs
- shared publish wrappers for major message types
- configure store-then-notify flow
- explicit shared helpers for result and status publication

## Requirements covered
- NATS-LIB-12
- NATS-LIB-15
- NATS-LIB-20
- NATS-LIB-21
- NATS-LIB-22

## What changed
- added `internal/subjects` for subject generation and validation
- centralized subject construction for:
  - `cmd.configure.<target>`
  - `cmd.action.<target>.<action>`
  - `result.<target>`
  - `status.<target>`
- added shared publish helpers in transport/messaging layer
- implemented configure as:
  1. validate
  2. store desired config
  3. publish lightweight configure notification
- added explicit shared helpers for result and status publish paths
- reduced scattered raw subject string usage

## What is intentionally not included
- public `agentcore.Client` wiring to these internals
- subscribe wrappers
- handler registration
- reconnect-safe subscription restore
- receive-side result correlation support

## Why
This phase standardizes message routing and publish behavior so agents use one shared subject model and one shared set of publish paths instead of duplicating raw NATS logic across the codebase.

This PR is intentionally limited to internal Phase 3 groundwork. Public runtime/session/KV facade wiring remains deferred to later phases.
