### PR TITLE
test(phase3): add missing publish wrapper unit tests

### DIFF
--- a/PROMPTS/03-subjects-publish-tests.md
+++ b/PROMPTS/03-subjects-publish-tests.md
@@ -48,6 +48,7 @@ General test design rules:
 - On failure, assert whether returned ack/result should be nil where applicable
 - Always assert whether downstream side effects were skipped or already performed
 - Prefer wrapper-level tests, not only shared helper tests, for invalid input and publish failure paths
+- For each publish wrapper, include at least one invalid-routing-input test before publish is attempted
 - Keep tests readable, deterministic, and focused
 - Use small test doubles and explicit assertions rather than over-abstracting test helpers
 
@@ -112,6 +113,7 @@ Include tests for:
 - custom/internal clock is used for AcceptedAt if implementation supports it
 - SubmitAction rejects invalid target before publish
 - SubmitAction rejects invalid action before publish
+- PublishConfigureNotification rejects invalid target before publish
 - PublishResult rejects invalid target before publish
 - PublishStatus rejects invalid target before publish
 - PublishResult wraps publisher failure

--- a/internal/transport/publish_test.go
+++ b/internal/transport/publish_test.go
@@ -646,3 +646,63 @@ func TestPublishStatusWrapsPublisherFailure(t *testing.T) {
 		t.Fatal("expected wrapped publish cause to be reachable via errors.Is")
 	}
 }
+
+/*
+TC-TRANSPORT-PUBLISH-017
+Type: Negative
+Title: PublishConfigureNotification rejects invalid target before publish
+Summary:
+Verifies that configure notification publish validates target input before
+encoding and publishing.
+
+Validates:
+  - invalid target returns validate_target error
+  - publish side effect is skipped
+*/
+func TestPublishConfigureNotificationRejectsInvalidTargetBeforePublish(t *testing.T) {
+	paths, err := NewPublishPaths(subjects.NewDefaultBuilder())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	msg := validTransportConfigureNotification()
+	msg.Target = "vyos core"
+	pub := &stubPublisher{}
+
+	err = paths.PublishConfigureNotification(context.Background(), pub, msg)
+	requireTransportAgentcoreError(t, err, agentcore.CodeValidation, "validate_target", "target cannot contain whitespace")
+	if len(pub.calls) != 0 {
+		t.Fatalf("expected publish not to be called, got %d calls", len(pub.calls))
+	}
+}
+
+/*
+TC-TRANSPORT-PUBLISH-018
+Type: Positive
+Title: publishEncoded publishes successfully with valid dependencies
+Summary:
+Verifies that the shared publish helper succeeds and forwards subject and payload
+to the publisher when all dependencies are valid.
+
+Validates:
+  - helper returns nil for a successful publish
+  - publisher receives one call with expected subject and payload
+*/
+func TestPublishEncodedPublishesSuccessfullyWithValidDependencies(t *testing.T) {
+	pub := &stubPublisher{}
+	payload := []byte(`{"ok":true}`)
+
+	err := publishEncoded(context.Background(), pub, "publish_result", "result.vyos", payload)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected one publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].subject != "result.vyos" {
+		t.Fatalf("expected subject %q, got %q", "result.vyos", pub.calls[0].subject)
+	}
+	if string(pub.calls[0].payload) != string(payload) {
+		t.Fatalf("expected payload %s, got %s", string(payload), string(pub.calls[0].payload))
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds two missed Phase 3 unit tests and updates the Phase 3 test prompt so these cases are explicitly requested in future generated coverage.

Added:
- `TC-TRANSPORT-PUBLISH-017`
- `TC-TRANSPORT-PUBLISH-018`

## What changed

- updated `PROMPTS/03-subjects-publish-tests.md`
  - added an explicit rule to include invalid-routing-input coverage for each publish wrapper
  - explicitly added `PublishConfigureNotification rejects invalid target before publish`

- updated `internal/transport/publish_test.go`
  - added `TC-TRANSPORT-PUBLISH-017`
  - added `TC-TRANSPORT-PUBLISH-018`

## Why

These were small missing Phase 3 test cases in the earlier merged PR.
This follow-up completes publish-wrapper unit coverage and improves the prompt so similar gaps are less likely in future generated tests.

## Scope

This PR is test-only.
No production code changes are included.

Closes routerarchitects/TIP-olg-nats-agent-core#6 