### PR TITLE
feat(client): add custom reconnect callback handler option and verify recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ offloaded by the agent to a goroutine, worker pool, or internal job queue.
 This prevents later messages on the same subscription from being delayed and
 helps avoid backpressure in callback processing.
 
-The library owns subscription registration, callback binding, envelope decoding,
-and reconnect restore. Agents remain responsible for workload execution and
-handler concurrency policy.
+The library recovers from any panics thrown by user handlers (configure, action, result, status) or the custom reconnect handler. These panics are safely caught, logged, and reported to the registered `errorSink` (if provided) to prevent agent crashes.
+
+The library owns subscription registration, callback binding, envelope decoding, and reconnect restore. Agents remain responsible for workload execution and handler concurrency policy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Current code includes:
   - `RegisterStatusHandler(...)`
 - optional queue-group subscription option:
   - `WithQueueGroup(...)`
+- optional client constructor options:
+  - `WithReconnectHandler(...)`
 - deferred registration support before `Start(ctx)`
 - configure store-then-notify flow via `SubmitConfigure(...)`
 - direct action publish flow via `SubmitAction(...)`
@@ -222,6 +224,7 @@ The main public APIs currently usable by an owning agent are:
 - `RegisterActionHandler(...)`
 - `RegisterResultHandler(...)`
 - `RegisterStatusHandler(...)`
+- `WithReconnectHandler(...)`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ offloaded by the agent to a goroutine, worker pool, or internal job queue.
 This prevents later messages on the same subscription from being delayed and
 helps avoid backpressure in callback processing.
 
-The library recovers from any panics thrown by user handlers (configure, action, result, status) or the custom reconnect handler. These panics are safely caught, logged, and reported to the registered `errorSink` (if provided) to prevent agent crashes.
+The library recovers from any panics thrown by user configure, action, result, and status handlers (which are caught, logged, and recorded as metrics failures). For the custom reconnect handler, any caught panic is logged and also reported to the registered `errorSink` (if provided) to prevent agent crashes.
 
 The library owns subscription registration, callback binding, envelope decoding, and reconnect restore. Agents remain responsible for workload execution and handler concurrency policy.
 

--- a/REQUIREMENTS_CHECKLIST.md
+++ b/REQUIREMENTS_CHECKLIST.md
@@ -245,6 +245,7 @@ Checklist:
 - [ ] public sender-to-receiver integration tests exist
 - [ ] action/result round-trip integration test exists
 - [ ] reconnect restore is verified with public PublishResult after restart
+- [x] custom reconnect handler option is supported and executed only after subscription restore completes
 
 Commit note:
 - `feat(phase5): add bidirectional send/receive transport and reconnect restoration`

--- a/REQUIREMENTS_CHECKLIST.md
+++ b/REQUIREMENTS_CHECKLIST.md
@@ -246,6 +246,7 @@ Checklist:
 - [ ] action/result round-trip integration test exists
 - [ ] reconnect restore is verified with public PublishResult after restart
 - [x] custom reconnect handler option is supported and executed only after subscription restore completes
+- [x] custom reconnect handler recovers from panics and reports them to the errorSink
 
 Commit note:
 - `feat(phase5): add bidirectional send/receive transport and reconnect restoration`

--- a/SPEC.md
+++ b/SPEC.md
@@ -268,6 +268,7 @@ After reconnect, the library must:
 - restore subscriptions
 - restore handler registrations
 - rebuild required NATS/JetStream/KV handles as needed
+- invoke the custom reconnect handler (if registered using `WithReconnectHandler(handler func())`) only after all subscriptions are restored
 
 The library must also support agent recovery flows in which an agent:
 - starts or restarts
@@ -288,6 +289,7 @@ The public API should provide, at minimum, support for:
 - result/status publication
 - desired config store/load/watch
 - handler registration for configure, action, result, and status
+- custom reconnect handler registration via `WithReconnectHandler(handler func())`
 
 The desired-config read API should return the decoded current desired-config record, including the config UUID needed for sync decisions.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -308,6 +308,8 @@ The library must **not** implement deep cloud business-policy validation.
 
 Public APIs must return clear, typed errors with structured codes where appropriate.
 
+The library must safely recover from panics thrown in user-supplied callbacks and handlers (such as configure, action, result, status handlers, or the custom reconnect handler). The caught panic must be logged and propagated as an error to the registered `errorSink` without crashing the application.
+
 ---
 
 ## 14. Health and observability

--- a/SPEC.md
+++ b/SPEC.md
@@ -308,7 +308,7 @@ The library must **not** implement deep cloud business-policy validation.
 
 Public APIs must return clear, typed errors with structured codes where appropriate.
 
-The library must safely recover from panics thrown in user-supplied callbacks and handlers (such as configure, action, result, status handlers, or the custom reconnect handler). The caught panic must be logged and propagated as an error to the registered `errorSink` without crashing the application.
+The library must safely recover from panics thrown in user-supplied configure, action, result, and status handlers (which are caught, logged, and recorded in metrics as failures) and the custom reconnect handler, preventing application crashes. For session-level connection/reconnection failures and panics originating in the custom reconnect handler callback, errors/panics must also be propagated to the registered `errorSink` (if provided).
 
 ---
 

--- a/agentcore/client.go
+++ b/agentcore/client.go
@@ -43,10 +43,11 @@ type SubscriptionOptions struct {
 }
 
 type clientOptions struct {
-	logger    Logger
-	metrics   Metrics
-	now       func() time.Time
-	errorSink func(error)
+	logger           Logger
+	metrics          Metrics
+	now              func() time.Time
+	errorSink        func(error)
+	reconnectHandler func()
 }
 
 // Option applies an optional public client setting during construction.
@@ -83,6 +84,14 @@ func WithClock(now func() time.Time) Option {
 func WithErrorSink(fn func(error)) Option {
 	return func(opts *clientOptions) error {
 		opts.errorSink = fn
+		return nil
+	}
+}
+
+// WithReconnectHandler registers a handler to be invoked when the NATS session is reconnected.
+func WithReconnectHandler(handler func()) Option {
+	return func(opts *clientOptions) error {
+		opts.reconnectHandler = handler
 		return nil
 	}
 }

--- a/agentcore/client_test.go
+++ b/agentcore/client_test.go
@@ -745,3 +745,134 @@ func TestStartupReconcileDelegatesToLoadDesiredConfigPath(t *testing.T) {
 		t.Fatalf("expected error op %q, got %q", "key_value", got.Op)
 	}
 }
+
+/*
+TC-CLIENT-011
+Type: Positive
+Title: WithReconnectHandler registers correctly and fires on reconnect
+Summary:
+Verifies that WithReconnectHandler registers the handler in options and invokes
+it when onSessionReconnected runs during connection recovery.
+
+Validates:
+  - constructor accepts WithReconnectHandler option
+  - reconnect handler fires when onSessionReconnected is called with callbacks enabled
+*/
+func TestWithReconnectHandlerOption(t *testing.T) {
+	fired := false
+	handler := func() {
+		fired = true
+	}
+
+	client, err := New(testConfig(), WithReconnectHandler(handler))
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	if client.options.reconnectHandler == nil {
+		t.Fatal("expected reconnectHandler option to be stored on client")
+	}
+
+	// Enable callbacks to simulate active running state
+	client.callbacksEnabled.Store(true)
+
+	// Invoke the callback triggering onSessionReconnected
+	client.onSessionReconnected()
+
+	if !fired {
+		t.Fatal("expected reconnect handler to be fired")
+	}
+}
+
+/*
+TC-CLIENT-012
+Type: Negative
+Title: Reconnect handler does not fire when callbacks are disabled
+Summary:
+Verifies that the reconnect handler is not invoked if callbacks are disabled.
+
+Validates:
+  - reconnect handler is not fired when callbacksEnabled is false
+*/
+func TestWithReconnectHandler_CallbacksDisabled(t *testing.T) {
+	fired := false
+	handler := func() {
+		fired = true
+	}
+
+	client, err := New(testConfig(), WithReconnectHandler(handler))
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	// Keep callbacks disabled
+	client.callbacksEnabled.Store(false)
+
+	client.onSessionReconnected()
+
+	if fired {
+		t.Fatal("expected reconnect handler not to fire when callbacks are disabled")
+	}
+}
+
+/*
+TC-CLIENT-013
+Type: Positive
+Title: Reconnect handler is safe to run when nil
+Summary:
+Verifies that the client does not panic when onSessionReconnected is called without a registered reconnect handler.
+
+Validates:
+  - client does not panic when reconnectHandler option is nil (unregistered)
+*/
+func TestWithReconnectHandler_NoHandlerRegistered(t *testing.T) {
+	client, err := New(testConfig())
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	client.callbacksEnabled.Store(true)
+
+	// Invoke onSessionReconnected without registering a reconnect handler.
+	// This should run without panicking.
+	client.onSessionReconnected()
+}
+
+/*
+TC-CLIENT-014
+Type: Negative
+Title: Reconnect handler does not fire if subscription restore fails
+Summary:
+Verifies that the reconnect handler is not invoked when one or more registered subscriptions fail to restore.
+
+Validates:
+  - reconnect handler is not fired if restoreAllRegisteredSubscriptions returns a non-nil error
+*/
+func TestWithReconnectHandler_SubscriptionRestoreFailed(t *testing.T) {
+	fired := false
+	handler := func() {
+		fired = true
+	}
+
+	client, err := New(testConfig(), WithReconnectHandler(handler))
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	// Register a configure handler (which creates a subscription record)
+	err = client.RegisterConfigureHandler("vyos", func(context.Context, ConfigureNotification) error { return nil })
+	if err != nil {
+		t.Fatalf("failed to register handler: %v", err)
+	}
+
+	client.callbacksEnabled.Store(true)
+
+	// Since we are not started, client.session lacks an active connection,
+	// so attempting to restore the subscription will return a connection/disconnected error.
+	// This will cause restoreAllRegisteredSubscriptions to return a non-nil error.
+	client.onSessionReconnected()
+
+	if fired {
+		t.Fatal("expected reconnect handler not to fire because subscription restore failed")
+	}
+}

--- a/agentcore/client_test.go
+++ b/agentcore/client_test.go
@@ -876,3 +876,49 @@ func TestWithReconnectHandler_SubscriptionRestoreFailed(t *testing.T) {
 		t.Fatal("expected reconnect handler not to fire because subscription restore failed")
 	}
 }
+
+/*
+TC-CLIENT-015
+Type: Positive
+Title: Reconnect handler panic is caught and reported to error sink
+Summary:
+Verifies that client recovers gracefully from a panicking reconnect handler,
+preventing application crash and propagating the panic as a formatted error
+to the registered errorSink.
+
+Validates:
+  - client catches panic thrown by reconnect handler
+  - caught panic does not abort execution
+  - formatted error is forwarded to options.errorSink
+*/
+func TestWithReconnectHandlerPanicSafety(t *testing.T) {
+	panicMsg := "simulated database reconnect failure"
+	var caughtErr error
+	sink := func(err error) {
+		caughtErr = err
+	}
+
+	handler := func() {
+		panic(panicMsg)
+	}
+
+	client, err := New(testConfig(), WithReconnectHandler(handler), WithErrorSink(sink))
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	client.callbacksEnabled.Store(true)
+
+	// Invoke the callback triggering onSessionReconnected
+	// This function must run to completion without panicking.
+	client.onSessionReconnected()
+
+	if caughtErr == nil {
+		t.Fatal("expected panic to be reported to error sink, got nil error")
+	}
+
+	expectedMsg := "reconnect handler panicked: simulated database reconnect failure"
+	if caughtErr.Error() != expectedMsg {
+		t.Fatalf("expected error message %q, got %q", expectedMsg, caughtErr.Error())
+	}
+}

--- a/agentcore/handlers_runtime.go
+++ b/agentcore/handlers_runtime.go
@@ -362,6 +362,9 @@ func (c *Client) onSessionReconnected() {
 		return
 	}
 	c.logInfo("subscription restore completed")
+	if c.options.reconnectHandler != nil {
+		c.options.reconnectHandler()
+	}
 }
 
 func (c *Client) onSessionClosed() {

--- a/agentcore/handlers_runtime.go
+++ b/agentcore/handlers_runtime.go
@@ -363,7 +363,18 @@ func (c *Client) onSessionReconnected() {
 	}
 	c.logInfo("subscription restore completed")
 	if c.options.reconnectHandler != nil {
-		c.options.reconnectHandler()
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err := fmt.Errorf("reconnect handler panicked: %v", r)
+					c.logError("reconnect handler panicked", "error", err)
+					if c.options.errorSink != nil {
+						c.options.errorSink(err)
+					}
+				}
+			}()
+			c.options.reconnectHandler()
+		}()
 	}
 }
 


### PR DESCRIPTION
# PR Title
`feat(client): add custom reconnect callback handler option and verify recovery`

# Parent Ticket
routerarchitects/TIP-olg-nats-agent-core#1 https://github.com/routerarchitects/TIP-olg-nats-agent-core/issues/1

# Summary
This PR implements a new connection reconnect callback hook (`WithReconnectHandler`) in `agentcore.Client`. This allows consuming downstream client/agent applications to register a custom callback that is automatically executed as soon as the NATS session successfully reconnects and recovers subscriptions.

# What This PR Covers
- **API Extension:** Defines the `WithReconnectHandler(handler func()) Option` constructor option in `agentcore/client.go`.
- **State Storage:** Adds the `reconnectHandler func()` field to the internal `clientOptions` struct to persist the registered callback.
- **Execution Hook:** Wires the callback invocation into `onSessionReconnected()` in `agentcore/handlers_runtime.go`, ensuring it triggers immediately after subscription restore completes.
- **Testing & Verification:** Adds robust positive, negative, and edge-case unit test coverage (`TC-CLIENT-011` through `TC-CLIENT-014`) in `agentcore/client_test.go`.
- **Documentation:** Updates `SPEC.md`, `README.md`, and `REQUIREMENTS_CHECKLIST.md` to document the new callback behavior, public API checklists, and verified integration test runs.

# Why This PR Is Needed
Currently, downstream client applications have no event-driven mechanism to detect when a dropped connection is restored. The new hook allows these applications to run critical self-healing, reconciliation, or state-synchronization logic immediately upon NATS session recovery without resorting to polling.

# How This PR Is Implemented
- **Option Registration:** The functional option `WithReconnectHandler` registers the handler on the internal `clientOptions` struct during initialization.
- **Execution Hook:** Inside `onSessionReconnected()`, the callback is invoked if it is not nil. This invocation runs strictly after `restoreAllRegisteredSubscriptions()` has successfully completed.
- **Safety Handling:** The callback is bypassed if callbacks are disabled or if subscription restoration fails, guaranteeing execution only on a fully healthy, restored connection.

# Reviewer Guide
Focus your review on:
1. Is the callback execution sequence inside `onSessionReconnected` correct? (Specifically, does it trigger only after subscription recovery returns without error?)
2. Are the new unit tests (`TC-CLIENT-011` through `TC-CLIENT-014`) verifying all expected execution flows, including edge cases (callbacks disabled, nil handlers, restore failure)?
3. Are there any concurrency/safety issues with accessing `c.options.reconnectHandler` during runtime callbacks?

# Please Do Not Expect Yet
- Downstream usage of this hook in active agent implementations (this PR focuses entirely on the core client capability).

# Files/Folders to Review
- `agentcore/client.go` (Option definition and storage)
- `agentcore/handlers_runtime.go` (Execution trigger in lifecycle)
- `agentcore/client_test.go` (Unit tests)
- `SPEC.md`, `README.md`, `REQUIREMENTS_CHECKLIST.md` (Docs)

# Phase Mapping
- Core Client Library Enhancements (NATS Session Recovery Hooks).

# Phase Acceptance Criteria
- [x] Downstream applications can pass `WithReconnectHandler` to `New()`.
- [x] Reconnection handler callback triggers as soon as NATS reconnection succeeds and subscriptions are restored.
- [x] Safe execution is guaranteed even if no handler is provided or if subscription restore fails.

# Test Evidence / CI Validation
All tests compile and run successfully:
- Unit tests: `go test -v ./agentcore/...` -> **PASS**
- Specific reconnect handler coverage checks:
```bash
go test -v ./agentcore -run TestWithReconnectHandlerOption
```

# Out of Scope
- Downstream self-healing state reconciliation logic inside the core library itself.

# Reviewer Checklist
Please verify:
- [ ] Reconnect callback fires after subscription restore succeeds.
- [ ] Reconnect callback does not fire if session recovery fails.
- [ ] The callback is safe to trigger when `reconnectHandler` is nil.
- [ ] Test comments are documented with `Type`, `Title`, `Summary`, and `Validates` fields.

# Notes for Reviewer
The callback runs synchronously inside the connection event handler. If the consumer's callback is long-running or blocking, it should spawn its own goroutine to avoid blocking the event loop.

# The key question is:
Does the new `WithReconnectHandler` callback hook execute safely, at the correct point in the NATS session recovery cycle, and with full unit test coverage?
```